### PR TITLE
Fixed bug for timestamps with leading zeros for microseconds.

### DIFF
--- a/async_rithmic/plants/base.py
+++ b/async_rithmic/plants/base.py
@@ -556,8 +556,7 @@ class BasePlant(BackgroundTaskMixin):
         return dt
 
     def _ssboe_usecs_to_datetime(self, ssboe: int, usecs: int):
-        ts = '{0}.{1}'.format(ssboe, usecs)
-        return datetime.fromtimestamp(float(ts), tz=pytz.utc)
+        return datetime.fromtimestamp(ssboe, tz=pytz.utc).replace(microsecond=usecs)
 
     def _datetime_to_ssboe_usecs(self, dt: datetime):
         """


### PR DESCRIPTION
leading zeros for data_bar_usecs resulted in incorrect datetime values due to string concatenation. Using datetime.replace(microsecond=<xx>) instead. 
