### PR TITLE
Handle rpCode '7' (no data) as empty result instead of error

### DIFF
--- a/async_rithmic/plants/base.py
+++ b/async_rithmic/plants/base.py
@@ -353,6 +353,9 @@ class BasePlant(BackgroundTaskMixin):
                 break
 
         if len(responses[-1].rp_code) and responses[-1].rp_code[0] != '0':
+            if responses[-1].rp_code[0] == '7':
+                self.logger.debug(f"Rithmic returned no data for the request={kwargs}")
+                return []
             raise RithmicErrorResponse(f"Rithmic returned an error={MessageToDict(responses[-1])} for the request={kwargs}")
 
         return responses
@@ -379,6 +382,9 @@ class BasePlant(BackgroundTaskMixin):
                 break
 
         if len(response.rp_code) and response.rp_code[0] != '0':
+            if response.rp_code[0] == '7':
+                self.logger.debug(f"Rithmic returned no data for the request={kwargs}")
+                return response
             raise RithmicErrorResponse(f"Rithmic returned an error={MessageToDict(response)} for the request={kwargs}")
 
         return response
@@ -529,6 +535,10 @@ class BasePlant(BackgroundTaskMixin):
             if self.request_manager.has_pending(request_id):
                 if response.rp_code:
                     if response.rp_code[0] != '0':
+                        if response.rp_code[0] == '7':
+                            self.logger.debug(f"Rithmic returned no data for request_id={request_id}")
+                            self.request_manager.mark_complete(request_id)
+                            return True
                         request = self.request_manager.requests.get(request_id)
                         self.request_manager.mark_complete(request_id)
                         raise RithmicErrorResponse(f"Rithmic returned an error={MessageToDict(response)} for the request={request}")


### PR DESCRIPTION
Rithmic returns rpCode=['7', 'no data'] when a query has no results (e.g., order history for an account with no trades). This is not an error condition - treat it as an empty result and log at debug level instead of raising RithmicErrorResponse.

Fixes all three code paths: _send_and_recv_immediate, _send_and_recv, and _process_response (request manager flow).