### PR TITLE
Allow passing order object to modify_order() to skip get_order() call

### DIFF
--- a/async_rithmic/plants/order.py
+++ b/async_rithmic/plants/order.py
@@ -322,9 +322,15 @@ class OrderPlant(BasePlant):
         - `target_ticks`: New take-profit in ticks
 
         Note: we can't update SL/TP/main order concurrently or Rithmic will send back an error: 'Atomic order operation in progress'
+
+        For time-critical modifications, pass `order=` with an object containing
+        the required fields (account_id, basket_id, symbol, exchange, quantity,
+        price_type, price) to skip the get_order() network call.
         """
 
-        order = await self.get_order(**kwargs)
+        order = kwargs.pop('order', None)
+        if order is None:
+            order = await self.get_order(**kwargs)
         if not order:
             raise Exception(f"Order not found: {kwargs}")
 


### PR DESCRIPTION
For time-critical order modifications (e.g., bracket modifications during position reversals), the get_order() call adds ~500-800ms of network latency.

Callers can now pass `order=` with an object containing the required fields (account_id, basket_id, symbol, exchange, quantity, price_type, price) to skip the lookup. Existing callers without `order=` are unaffected.

Fixes #46