### PR TITLE
fix(concurrency): split send/recv locks so heartbeat & recv loop never block each other

### DIFF
--- a/async_rithmic/helpers/background_task_mixin.py
+++ b/async_rithmic/helpers/background_task_mixin.py
@@ -57,7 +57,7 @@ class BackgroundTaskMixin:
                 async with DisconnectionHandler(self):
                     buffer = None
 
-                    async with try_acquire_lock(self, context="_recv_loop"):
+                    async with try_acquire_lock(self, context="_recv_loop", lock=self.recv_lock):
                         try:
                             buffer = await asyncio.wait_for(self._recv(), timeout=self.listen_interval)
                         except asyncio.TimeoutError:

--- a/async_rithmic/helpers/concurrency.py
+++ b/async_rithmic/helpers/concurrency.py
@@ -3,18 +3,25 @@ import traceback
 from contextlib import asynccontextmanager
 
 @asynccontextmanager
-async def try_acquire_lock(plant, timeout: float = 10.0, context: str = ""):
+async def try_acquire_lock(plant, timeout: float = 10.0, context: str = "", lock=None):
     """
     Attempts to acquire an asyncio.Lock with timeout.
     Logs and raises on timeout to help detect deadlocks.
+
+    `lock` selects which lock to take; defaults to plant.send_lock (the SEND lock).
+    The recv loop / inline-recv paths pass plant.recv_lock so reads never block the
+    heartbeat send, and sends never block reads.
     """
+
+    if lock is None:
+        lock = plant.send_lock
 
     acquired = False
     try:
-        await asyncio.wait_for(plant.lock.acquire(), timeout=timeout)
+        await asyncio.wait_for(lock.acquire(), timeout=timeout)
 
         acquired = True
-        plant.lock._current_context = context
+        lock._current_context = context
 
         yield
 
@@ -22,7 +29,7 @@ async def try_acquire_lock(plant, timeout: float = 10.0, context: str = ""):
         plant.logger.error(f"[LOCK TIMEOUT] Failed to acquire lock after {timeout:.2f}s.")
         plant.logger.error(f"[WAITING CONTEXT] {context}")
 
-        blocking_context = getattr(plant.lock, "_current_context", None)
+        blocking_context = getattr(lock, "_current_context", None)
         if blocking_context:
             plant.logger.error(f"[BLOCKING CONTEXT] {blocking_context}")
 
@@ -31,5 +38,5 @@ async def try_acquire_lock(plant, timeout: float = 10.0, context: str = ""):
 
     finally:
         if acquired:
-            plant.lock._current_context = None
-            plant.lock.release()
+            lock._current_context = None
+            lock.release()

--- a/async_rithmic/plants/base.py
+++ b/async_rithmic/plants/base.py
@@ -153,7 +153,8 @@ class BasePlant(BackgroundTaskMixin):
 
         self.ws = None
         self.client = client
-        self.lock = asyncio.Lock()
+        self.send_lock = asyncio.Lock()  # SEND lock: serializes ALL websocket writes (incl. heartbeat); concurrent ws.send() is unsafe
+        self.recv_lock = asyncio.Lock()  # RECV lock: serializes websocket reads (recv loop + inline-recv) so reads never block the heartbeat send
         self.request_manager = RequestManager(self)
 
         # Heartbeats have to be sent every {interval} seconds, unless an update was received
@@ -344,13 +345,17 @@ class BasePlant(BackgroundTaskMixin):
         """
         responses = []
 
-        async with try_acquire_lock(self, context=f"send_and_recv_immediate_{kwargs.get('template_id')}"):
+        # Hold the RECV lock across the send+recv (serializes with _recv_loop — no concurrent
+        # ws.recv()), and take the SEND lock only for the write. The heartbeat (send lock only)
+        # is therefore never blocked by this inline recv.
+        async with try_acquire_lock(self, context=f"send_and_recv_immediate_{kwargs.get('template_id')}", lock=self.recv_lock):
 
             request = self._build_request(**kwargs)
             self.logger.debug(f"Sending message {MessageToDict(request)}")
 
             buffer = self._convert_request_to_bytes(request)
-            await self.ws.send(buffer)
+            async with try_acquire_lock(self, context=f"send_immediate_{kwargs.get('template_id')}"):
+                await self.ws.send(buffer)
 
             while True:
                 buffer = await self.ws.recv()
@@ -387,7 +392,7 @@ class BasePlant(BackgroundTaskMixin):
 
         while True:
             async with DisconnectionHandler(self):
-                async with try_acquire_lock(self, context=f"send_and_recv_{template_id}"):
+                async with try_acquire_lock(self, context=f"send_and_recv_{template_id}", lock=self.recv_lock):
                     buffer = await self._recv()
 
                 response = self._convert_bytes_to_response(buffer)

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -110,8 +110,10 @@ async def test_no_deadlock_on_reconnect(ticker_plant_mock, function_name):
 
 
     async def fake_connect():
-        # Simulate reconnect path that also acquires the lock
-        async with plant.lock:
+        # Simulate a reconnect path that also acquires the lock the recv-path listener
+        # holds (recv_lock since the send/recv lock split), to assert no deadlock: the
+        # listener must release it on disconnect so the reconnect can proceed.
+        async with plant.recv_lock:
             await asyncio.sleep(0.1)
 
     plant._connect = fake_connect


### PR DESCRIPTION
## Summary

Split the single per-plant `self.lock` into two locks — `send_lock` and
`recv_lock` — so the heartbeat send and the recv loop can never block each
other. This removes a class of self-inflicted keepalive starvation under load
without weakening any of the safety the single lock provided.

## Background

Each plant runs three background coroutines on one event loop: `_recv_loop`,
`_process_loop`, `_heartbeat_loop`. Today they all contend for one
`self.lock`:

- `_recv_loop` holds it across `await ws.recv()` (bounded by `listen_interval`).
- `_send_and_recv` / `_send_and_recv_immediate` hold it across a full
  send→recv round-trip.
- `_send` / `_send_heartbeat` take it for each `ws.send`.

So a heartbeat (`template_id=18`) can queue behind an inline recv that is
itself waiting on the wire. When several plants share an event loop and traffic
is bursty, the heartbeat is delayed past the negotiated interval and Rithmic
drops the connection — triggering a reconnect storm that makes the contention
worse. The root issue is that **two genuinely independent concerns — writing to
the socket and reading from it — are serialized against each other**.

## What changed

Two locks with clear, non-overlapping responsibilities:

- **`send_lock`** — serializes *all* websocket writes (`ws.send`), including the
  heartbeat. Concurrent `ws.send()` on one connection is unsafe, so every write
  still goes through one lock. This is the default lock for `try_acquire_lock`.
- **`recv_lock`** — serializes websocket reads (`_recv_loop` + the inline-recv
  in `_send_and_recv` / `_send_and_recv_immediate`) so reads never collide and
  never block a write.

`try_acquire_lock(plant, ..., lock=None)` now takes an optional `lock` and
defaults to `plant.send_lock`. The recv paths pass `lock=self.recv_lock`.

`_send_and_recv_immediate` holds `recv_lock` for the whole send+recv op (it must
serialize with `_recv_loop` — no two coroutines may `ws.recv()` at once) but
takes `send_lock` only for the actual `ws.send`. So:

- the heartbeat (send_lock) is never blocked by an inline recv (recv_lock);
- concurrent writes are still fully serialized (send_lock);
- concurrent reads are still fully serialized (recv_lock).

## Deadlock safety

The only nesting is **recv→send** (inside `_send_and_recv_immediate`); there is
no send→recv path anywhere, so there is no lock-ordering cycle. The existing
reconnect-deadlock regression (`test_no_deadlock_on_reconnect`) is updated to
acquire `recv_lock` in its simulated reconnect (the lock the recv listener
holds) and still passes.

## Tests

`pytest -q` green on top of `v1.6.1`. `test_no_deadlock_on_reconnect` updated
for the rename; all other tests unchanged.

## Relationship to #59 / #53

This is independent of and complementary to the historical-data rewrite (#59).
With #59, history fetches no longer hold a lock across a recv, so the most
acute starvation source is already gone; this split is the structural
guarantee that send and recv can't serialize against each other on *any* path,
which keeps the heartbeat reliable under arbitrary load. It is also independent
of the order-terminal-ack fix in #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
