### PR TITLE
Fail-soft on unknown template ids + map template 358 (AccountRmsUpdates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- Order: added `on_account_rms_update` callback for account RMS updates (template id 358).
+
+### Fixed
+- Fail-soft on unmapped template ids: instead of raising (which flooded the logs with tracebacks for every message), the read loop now warns once per unknown template id and drops the message.
+
 ## [1.6.2] - 2026-06-05
 ### Added
 - Refactored reconnect flow to improve reliability

--- a/async_rithmic/client.py
+++ b/async_rithmic/client.py
@@ -46,6 +46,7 @@ class RithmicClient(DelegateMixin):
         self.on_exchange_order_notification = Event()
         self.on_bracket_update = Event()
         self.on_trade_route_update = Event()
+        self.on_account_rms_update = Event()
 
         # Historical data events
         self.on_historical_tick = Event()

--- a/async_rithmic/helpers/background_task_mixin.py
+++ b/async_rithmic/helpers/background_task_mixin.py
@@ -149,6 +149,10 @@ class BackgroundTaskMixin:
             buffer = await self._inbound_queue.get()
             try:
                 response = self._convert_bytes_to_response(buffer)
+                if response is None:
+                    # Unmapped template id (already warned once in
+                    # _convert_bytes_to_response) — drop it and keep going.
+                    continue
                 self.logger.debug(f"Received message {MessageToDict(response)}")
 
                 await self._process_response(response)

--- a/async_rithmic/plants/base.py
+++ b/async_rithmic/plants/base.py
@@ -102,6 +102,7 @@ TEMPLATES_MAP = {
     351: pb.rithmic_order_notification_pb2.RithmicOrderNotification,
     352: pb.exchange_order_notification_pb2.ExchangeOrderNotification,
     353: pb.bracket_updates_pb2.BracketUpdates,
+    358: pb.account_rms_updates_pb2.AccountRmsUpdates,
 
     3504: pb.request_exit_position_pb2.RequestExitPosition,
     3505: pb.response_exit_position_pb2.ResponseExitPosition,
@@ -174,6 +175,12 @@ class BasePlant(BackgroundTaskMixin):
 
         # Keep list of subscriptions in order to resubscribe automatically after disconnections
         self._subscriptions = defaultdict(set)
+
+        # Template ids we've already warned about (see _convert_bytes_to_response).
+        # Rithmic can push message types this library doesn't map yet; we log the
+        # first occurrence of each and then stay quiet so a single unknown stream
+        # doesn't flood the logs with tracebacks.
+        self._warned_unknown_template_ids = set()
 
     @property
     def is_connected(self) -> bool:
@@ -366,6 +373,10 @@ class BasePlant(BackgroundTaskMixin):
                 buffer = await self.ws.recv()
 
                 response = self._convert_bytes_to_response(buffer)
+                if response is None:
+                    # Unmapped template id (already warned once) — keep waiting
+                    # for the response we actually expect.
+                    continue
                 self.logger.debug(f"Received message {MessageToDict(response)}")
 
                 if response.template_id != kwargs["template_id"] + 1:
@@ -449,6 +460,12 @@ class BasePlant(BackgroundTaskMixin):
     def _convert_bytes_to_response(self, buffer):
         """
         Bytes to Response class conversion
+
+        Returns ``None`` when the message carries a template id this library
+        does not map. Rithmic occasionally pushes message types we don't
+        handle yet; treating that as fatal caused the read loop to log a full
+        traceback for every such message, flooding the logs. Instead we warn
+        once per unknown template id and let the caller skip the message.
         """
         raw_data = buffer[4:]
 
@@ -458,7 +475,14 @@ class BasePlant(BackgroundTaskMixin):
 
         template_id = base.template_id
         if template_id not in TEMPLATES_MAP:
-            raise Exception(f"Unknown template ID: {template_id}")
+            if template_id not in self._warned_unknown_template_ids:
+                self._warned_unknown_template_ids.add(template_id)
+                self.logger.warning(
+                    f"Received a message with an unmapped template_id={template_id}; "
+                    "ignoring it. Further messages with this template id will be "
+                    "silently dropped."
+                )
+            return None
 
         # Parse as specific response class
         response_cls = TEMPLATES_MAP[template_id]

--- a/async_rithmic/plants/order.py
+++ b/async_rithmic/plants/order.py
@@ -522,5 +522,9 @@ class OrderPlant(BasePlant):
             # Bracket update
             await self.client.on_bracket_update.call_async(response)
 
+        elif response.template_id == 358:
+            # Account RMS update (auto-liquidation thresholds, buying power, etc.)
+            await self.client.on_account_rms_update.call_async(response)
+
         else:
             self.logger.warning(f"Unhandled inbound message with template_id={response.template_id}")

--- a/tests/test_unknown_template.py
+++ b/tests/test_unknown_template.py
@@ -1,0 +1,97 @@
+import asyncio
+import logging
+from contextlib import suppress
+from unittest.mock import AsyncMock
+
+from pattern_kit import Event
+
+from async_rithmic import protocol_buffers as pb
+from conftest import _convert_proto_message_to_bytes
+
+
+def _base_buffer(template_id):
+    """Build a length-prefixed buffer carrying only a template id."""
+    message = pb.base_pb2.Base()
+    message.template_id = template_id
+    return _convert_proto_message_to_bytes(message)
+
+
+def test_unknown_template_id_returns_none_and_warns_once(order_plant_mock, caplog):
+    """
+    An unmapped template id must not raise (which used to flood the logs with a
+    full traceback for every such message). It returns None and logs a single
+    warning per template id.
+    """
+    buffer = _base_buffer(9999)
+
+    with caplog.at_level(logging.WARNING):
+        first = order_plant_mock._convert_bytes_to_response(buffer)
+        second = order_plant_mock._convert_bytes_to_response(buffer)
+
+    assert first is None
+    assert second is None
+    assert order_plant_mock._warned_unknown_template_ids == {9999}
+
+    warnings = [
+        r for r in caplog.records
+        if r.levelno == logging.WARNING and "9999" in r.getMessage()
+    ]
+    assert len(warnings) == 1
+
+
+async def test_process_loop_drops_unknown_and_keeps_going(order_plant_mock):
+    """
+    The processing loop must silently drop an unmapped message and continue
+    dispatching the messages that follow it.
+    """
+    plant = order_plant_mock
+    plant._process_response = AsyncMock()
+
+    unknown = _base_buffer(9999)
+
+    known_msg = pb.response_heartbeat_pb2.ResponseHeartbeat()
+    known_msg.template_id = 19
+    known = _convert_proto_message_to_bytes(known_msg)
+
+    await plant._inbound_queue.put(unknown)
+    await plant._inbound_queue.put(known)
+
+    task = asyncio.create_task(plant._process_loop())
+    await asyncio.sleep(0.05)
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
+
+    # Only the known message reached _process_response; the unknown one was dropped
+    assert plant._process_response.await_count == 1
+    assert plant._process_response.await_args.args[0].template_id == 19
+
+
+async def test_account_rms_update_decodes_and_fires_event(order_plant_mock):
+    """
+    A template id 358 frame decodes to AccountRmsUpdates and is dispatched to
+    the on_account_rms_update callback.
+    """
+    plant = order_plant_mock
+
+    received = []
+
+    async def callback(message):
+        received.append(message)
+
+    plant.client.on_account_rms_update = Event()
+    plant.client.on_account_rms_update += callback
+
+    msg = pb.account_rms_updates_pb2.AccountRmsUpdates()
+    msg.template_id = 358
+    msg.account_id = "TEST_ACCT"
+    buffer = _convert_proto_message_to_bytes(msg)
+
+    response = plant._convert_bytes_to_response(buffer)
+    assert isinstance(response, pb.account_rms_updates_pb2.AccountRmsUpdates)
+    assert response.template_id == 358
+
+    await plant._process_response(response)
+
+    assert len(received) == 1
+    assert received[0].account_id == "TEST_ACCT"


### PR DESCRIPTION
Fixes #66.

The order plant floods the logs with ERROR tracebacks (`Unknown template ID: 358`) when Rithmic pushes a message type the library does not map. This PR has two parts that stand independently.

## 1. Fail-soft on unmapped template ids

`BasePlant._convert_bytes_to_response` raised `Exception(f"Unknown template ID: {template_id}")` for any template id missing from `TEMPLATES_MAP`. That exception is caught by the read/process loop and logged via `logger.exception(...)`, so a single recurring unmapped message type produces a full traceback for **every** message and drowns out real errors.

It now:
- warns **once per template id** (dedupe set on the plant instance) and returns `None`,
- and the read loops (`_process_loop` in `background_task_mixin.py` and the inline loop in `_send_and_recv_immediate`) skip a `None` response and continue.

This half is safe regardless of what template 358 actually is — it just stops one unhandled message type from flooding the logs.

## 2. Map template 358 → `AccountRmsUpdates`

`account_rms_updates_pb2.AccountRmsUpdates` is already vendored in `protocol_buffers/` but was never registered in `TEMPLATES_MAP`. This adds:
- `358: pb.account_rms_updates_pb2.AccountRmsUpdates` to `TEMPLATES_MAP`,
- a dispatch branch in `OrderPlant._process_response` firing a new `on_account_rms_update` client event, mirroring how `on_bracket_update` (353) is wired.

**On the 358 == AccountRmsUpdates mapping:** this is verified circumstantially, not from an official Rithmic spec. On a live Rithmic paper session the template-358 frames decode cleanly against `AccountRmsUpdates` (the RMS fields — auto-liquidation thresholds, buying power, etc. — populate correctly), and 358 sits in the order-plant notification range right after the 350–353 notifications. If you'd rather not commit to the mapping without an official reference, the fail-soft half (part 1) resolves the log-flood on its own and I'm happy to split this into two PRs — just let me know your preference.

## Tests

Added `tests/test_unknown_template.py` (matches the existing plant-mock idiom):
- an unmapped template id yields a single warning, no raise, `None` return, and the process loop keeps dispatching subsequent messages;
- a 358 frame decodes to `AccountRmsUpdates` and fires `on_account_rms_update`.

Full suite: `30 passed` locally (27 pre-existing + 3 new) via `PYTHONPATH=. pytest tests` on Python 3.12. No live credentials required — everything runs against the existing offline mocks.
