### PR TITLE
Improved historical data replay with lossless tick pagination, strict incomplete-result handling, connection-loss errors, and   page-level progress callbacks for ticks and time bars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,23 @@ Public docstrings should briefly describe behavior, important side effects, and 
 
 Keep behavior in the narrowest appropriate owner. Do not move endpoint-specific logic into the client or base plant for convenience.
 
+
+## Testing style
+
+Tests should protect meaningful behavior without overspecifying incidental details.
+
+- Test public behavior, correctness invariants, important failure modes, and regressions.
+- Prefer a small number of high-signal scenario tests over many narrow micro-tests.
+- A test may assert several related outcomes when they belong to the same scenario. Do not split tests merely to achieve one assertion per test.
+- Keep one coherent behavior or scenario per test, not one field, branch, or assertion per test.
+- Avoid locking in implementation details such as private helper structure, incidental internal call counts, or exact intermediate state unless correctness depends on them.
+- Do not add exhaustive permutations of equivalent cases. Choose representative edge cases based on realistic failure risk.
+- Assert exact error text, ordering, formatting, or other small details only when they are part of the public contract or materially affect callers.
+- Add a regression test when a bug exposes a meaningful gap. Do not create tests solely to increase test count or line coverage.
+- When an existing test already exercises the changed behavior, extend it when that keeps the scenario readable instead of creating another near-duplicate test.
+
+The goal is confidence in general correctness with low cognitive load, not maximum test granularity.
+
 ## Python style
 
 - Use descriptive domain names.
@@ -86,6 +103,6 @@ Async lifecycle behavior is part of the public contract.
 - [ ] Comments are concise and useful.
 - [ ] Async tasks and request state are cleaned up.
 - [ ] Errors are explicit.
-- [ ] Focused tests cover the change.
+- [ ] Focused, high-signal tests cover meaningful behavior without overspecifying implementation details.
 - [ ] The full test suite passes.
 - [ ] The diff contains no unrelated changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+## Purpose
+
+`async_rithmic` is a focused async Python client for the Rithmic API.
+
+Contributions should preserve the codebase's defining qualities:
+
+- direct async control flow;
+- concrete protocol-facing code;
+- clear ownership by plant;
+- small public methods;
+- explicit failure behavior;
+- focused regression tests.
+
+## General style
+
+Favor simple, expressive code.
+
+- Prefer the smallest correct solution.
+- Keep the normal execution path easy to read from top to bottom.
+- Use direct method calls and explicit state.
+- Keep abstractions concrete and local.
+- Extract helpers only when they make the main flow easier to follow.
+- Avoid clever code when a short loop or condition is clearer.
+- Match the style of the surrounding module.
+- Keep diffs narrow and avoid unrelated cleanup.
+
+Do not redesign nearby code unless it is necessary for the requested change.
+
+## Comments and docstrings
+
+Keep comments concise.
+
+Comments should explain:
+
+- protocol behavior;
+- correctness invariants;
+- non-obvious edge cases;
+- why a seemingly simpler implementation is unsafe.
+
+Do not:
+
+- narrate obvious code;
+- repeat the function name;
+- write long implementation essays inside the source;
+- preserve outdated comments after behavior changes.
+
+Prefer expressive names and structure over explanatory comments.
+
+Public docstrings should briefly describe behavior, important side effects, and notable failure cases. Private helpers usually do not need docstrings when their purpose is clear from the name.
+
+## Repository ownership
+
+- `async_rithmic/client.py` constructs plants and delegates their public methods.
+- `async_rithmic/plants/base.py` owns behavior genuinely shared by all plants.
+- `async_rithmic/plants/*.py` own endpoint-specific requests, responses, and state.
+- `async_rithmic/helpers/` contains small reusable async mechanisms.
+- `async_rithmic/objects.py` contains simple state and configuration dataclasses.
+- `tests/` contains focused pytest tests.
+
+Keep behavior in the narrowest appropriate owner. Do not move endpoint-specific logic into the client or base plant for convenience.
+
+## Python style
+
+- Use descriptive domain names.
+- Prefer short functions with one clear responsibility.
+- Add type annotations where they improve understanding.
+- Preserve the existing public API unless a correctness fix requires a change.
+
+## Async correctness
+
+Async lifecycle behavior is part of the public contract.
+
+- Never perform blocking I/O or use blocking sleeps in async code.
+- Every long-lived task must have a clear owner and shutdown path.
+- Preserve cancellation. Catch `asyncio.CancelledError` only for cleanup, then re-raise it.
+- Do not leave callers blocked after an error.
+- Request state must be finalized or removed on success, timeout, cancellation, provider error, and local processing error.
+- When waiting on multiple tasks, cancel and clean up unfinished tasks.
+- Callbacks and returned results should contain the same accepted records in the same order unless documented otherwise.
+- Do not swallow exceptions. Broad catches are acceptable only for narrow cleanup or logging and should normally re-raise.
+
+## Final checklist
+
+- [ ] The normal execution path is easy to follow.
+- [ ] The solution is no more complex than necessary.
+- [ ] Comments are concise and useful.
+- [ ] Async tasks and request state are cleaned up.
+- [ ] Errors are explicit.
+- [ ] Focused tests cover the change.
+- [ ] The full test suite passes.
+- [ ] The diff contains no unrelated changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.7.0] - 2026-08-xx
+### Improved
+- Historical data replay with lossless tick pagination, strict incomplete-result handling, connection-loss errors, and page-level progress callbacks for ticks and time bars
+
 ## [1.6.4] - 2026-07-31
 ### Changed
 - Updated protobuf version requirement from `>=4.25.4,<5` to `>=5.29.3,<8`

--- a/async_rithmic/__init__.py
+++ b/async_rithmic/__init__.py
@@ -2,6 +2,10 @@ from .client import RithmicClient
 from .enums import *
 from .logger import logger
 from .exceptions import *
-from .objects import RetrySettings, ReconnectionSettings
+from .objects import (
+    HistoricalDataProgress,
+    ReconnectionSettings,
+    RetrySettings,
+)
 
 __version__ = '1.6.5'

--- a/async_rithmic/exceptions.py
+++ b/async_rithmic/exceptions.py
@@ -9,3 +9,18 @@ class InvalidRequestError(Exception):
 
 class HistoricalDataRequestInProgressError(RuntimeError):
     pass
+
+
+class HistoricalDataPaginationError(RuntimeError):
+    """Raised when historical data cannot be paginated without losing data."""
+    pass
+
+
+class HistoricalDataIncompleteError(RuntimeError):
+    """Raised when a historical request reaches its page limit incomplete."""
+    pass
+
+
+class HistoricalDataConnectionError(RuntimeError):
+    """Raised when a historical request is interrupted by a connection loss."""
+    pass

--- a/async_rithmic/helpers/background_task_mixin.py
+++ b/async_rithmic/helpers/background_task_mixin.py
@@ -71,6 +71,12 @@ class BackgroundTaskMixin:
             except (ConnectionClosedError, ConnectionClosedOK):
                 self.logger.warning("WebSocket connection closed — signalling reconnect")
                 self._disconnect_event.set()
+                try:
+                    await self.client.on_disconnected.call_async(self.plant_type)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    self.logger.exception("Error notifying connection loss")
                 return
 
             except asyncio.CancelledError:

--- a/async_rithmic/helpers/request_manager.py
+++ b/async_rithmic/helpers/request_manager.py
@@ -23,6 +23,13 @@ class RequestManager:
         self.expected_responses[request_id] = expected_response
         self.start_times[request_id] = time.time()
 
+    def _cleanup(self, request_id: str):
+        self.requests.pop(request_id, None)
+        self.responses.pop(request_id, None)
+        self.expected_responses.pop(request_id, None)
+        self.done_events.pop(request_id, None)
+        self.start_times.pop(request_id, None)
+
     async def send_and_collect(self, timeout: float = 30.0, **kwargs):
         """
         Sends a message and waits for all responses tied to the given request_id.
@@ -42,21 +49,21 @@ class RequestManager:
 
         self.plant.logger.debug(f"Sending request {request_id}")
         self.start(request_id, kwargs, expected_response)
-        await self.plant._send_request(**kwargs)
+        done_event = self.done_events[request_id]
 
         try:
-            await asyncio.wait_for(self.done_events[request_id].wait(), timeout=timeout)
+            await self.plant._send_request(**kwargs)
+            await asyncio.wait_for(done_event.wait(), timeout=timeout)
 
         except asyncio.TimeoutError:
             self.plant.logger.exception(f"Timeout waiting for complete response stream for request_id={request_id}")
-            self.done_events.pop(request_id, None)
-            self.expected_responses.pop(request_id, None)
             raise
 
         finally:
-            self.done_events.pop(request_id, None)
+            responses = self.responses.pop(request_id, [])
+            self._cleanup(request_id)
 
-        return self.responses.pop(request_id, [])
+        return responses
 
     def handle_response(self, response):
         """
@@ -86,8 +93,6 @@ class RequestManager:
             )
 
             self.done_events[request_id].set()
-
-            # Clean up
             self.done_events.pop(request_id, None)
             self.expected_responses.pop(request_id, None)
             self.start_times.pop(request_id, None)

--- a/async_rithmic/objects.py
+++ b/async_rithmic/objects.py
@@ -1,6 +1,15 @@
 import random
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Literal
+
+
+@dataclass(frozen=True, slots=True)
+class HistoricalDataProgress:
+    pages_requested: int
+    rows_received: int
+    last_timestamp: datetime | None
+    boundary_replay_count: int
 
 
 @dataclass

--- a/async_rithmic/plants/base.py
+++ b/async_rithmic/plants/base.py
@@ -288,7 +288,12 @@ class BasePlant(BackgroundTaskMixin):
         )
         return self._first(responses)
 
-    async def _send(self, message: bytes, template_id: int = None):
+    async def _send(
+        self,
+        message: bytes,
+        template_id: int = None,
+        retry_on_reconnect: bool = True,
+    ):
 
         try:
             async with try_acquire_lock(self, context=f"send_{template_id}"):
@@ -299,6 +304,8 @@ class BasePlant(BackgroundTaskMixin):
 
             self._disconnect_event.set()
             self._reconnected_event.clear()
+            if not retry_on_reconnect:
+                raise
             try:
                 await asyncio.wait_for(self._reconnected_event.wait(), timeout=60)
             except asyncio.TimeoutError:
@@ -315,7 +322,7 @@ class BasePlant(BackgroundTaskMixin):
     async def _recv(self):
         return await self.ws.recv()
 
-    async def _send_request(self, **kwargs):
+    async def _send_request(self, retry_on_reconnect: bool = True, **kwargs):
         """
         Create Request class instance, convert it to bytes and send it to the server
         """
@@ -324,7 +331,11 @@ class BasePlant(BackgroundTaskMixin):
 
         template_id = kwargs["template_id"]
         buffer = self._convert_request_to_bytes(request)
-        await self._send(buffer, template_id=template_id)
+        await self._send(
+            buffer,
+            template_id=template_id,
+            retry_on_reconnect=retry_on_reconnect,
+        )
 
         return template_id
 

--- a/async_rithmic/plants/history.py
+++ b/async_rithmic/plants/history.py
@@ -1,11 +1,20 @@
 from datetime import datetime
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 
 from .base import BasePlant
-from ..exceptions import HistoricalDataRequestInProgressError
+from ..exceptions import (
+    HistoricalDataConnectionError,
+    HistoricalDataIncompleteError,
+    HistoricalDataPaginationError,
+    HistoricalDataRequestInProgressError,
+    RithmicErrorResponse,
+)
 from ..enums import SysInfraType, TimeBarType
 from .. import protocol_buffers as pb
+
+HISTORICAL_TICK_PAGE_SIZE = 10_000
 
 
 @dataclass
@@ -30,7 +39,10 @@ class HistoricalDataRequest:
     data_received: asyncio.Event
     data: list[dict]
 
+    strict: bool = False
     last_marker: int = 0
+    tick_page: list[tuple[int, int, dict]] = field(default_factory=list)
+    error: BaseException | None = None
 
     @property
     def reached_max_pages(self) -> bool:
@@ -59,6 +71,7 @@ class HistoryPlant(BasePlant):
 
         self.client.on_historical_tick += self._on_historical_tick
         self.client.on_historical_time_bar += self._on_historical_time_bar
+        self.client.on_disconnected += self._on_disconnected
 
     async def _login(self):
         await super()._login()
@@ -81,6 +94,35 @@ class HistoryPlant(BasePlant):
         if (request := self.historical_tick_requests.get(key)) is not None:
             request.data.append(data)
             request.data_received.set()
+
+    async def _on_disconnected(self, plant_type):
+        if plant_type != self.plant_type:
+            return
+
+        for key, request in list(self.historical_tick_requests.items()):
+            self._finish_historical_tick_request(
+                key,
+                request,
+                HistoricalDataConnectionError(
+                    f"Historical tick replay for {key} was interrupted by "
+                    "a connection loss."
+                ),
+            )
+
+    def _finish_historical_tick_request(
+        self,
+        key: str,
+        request: HistoricalDataRequest,
+        error: BaseException | None = None,
+    ):
+        if error is not None and request.error is None:
+            request.error = error
+        request.done.set()
+        self.historical_tick_requests.pop(key, None)
+
+    def _fail_historical_tick_requests(self, error: BaseException):
+        for key, request in list(self.historical_tick_requests.items()):
+            self._finish_historical_tick_request(key, request, error)
 
     async def _wait_for_historical_request_completion(
         self,
@@ -120,6 +162,10 @@ class HistoryPlant(BasePlant):
                 for task in (done_task, data_task):
                     if not task.done():
                         task.cancel()
+                await asyncio.gather(done_task, data_task, return_exceptions=True)
+
+        if request.error is not None:
+            raise request.error
 
         return request.data
 
@@ -132,6 +178,7 @@ class HistoryPlant(BasePlant):
         wait: bool = True,
         idle_timeout: float = 5.0,
         max_pages: int = 1_000,
+        strict: bool = True,
     ):
         """
         Requests historical ticks for a symbol/exchange over a time range.
@@ -143,7 +190,7 @@ class HistoryPlant(BasePlant):
         :param wait: If True, wait for the historical replay to complete and return
             the collected ticks. If False, return immediately after sending the
             request; ticks are still emitted through the ``on_historical_tick``
-            callback.
+            callback after each provider page completes.
         :param idle_timeout: Maximum number of seconds to wait without receiving
             either a historical bar or the replay completion message. This is an
             idle/stall timeout, not a total request timeout; the timer resets every
@@ -152,10 +199,19 @@ class HistoryPlant(BasePlant):
             a single replay request without pagination. Values greater than `1` allow
             the client to issue additional replay requests until the returned bars cover
             the requested `end_time`. This handles Rithmic replay truncation.
+        :param strict: If True, reaching ``max_pages`` before natural replay
+            completion raises ``HistoricalDataIncompleteError``. If False, the
+            complete seconds received before the limit are returned.
         :return: A list of historical tick dictionaries when ``wait=True``;
             otherwise ``None``.
         :raises HistoricalDataRequestInProgressError: If another historical tick
             request is already in progress.
+        :raises HistoricalDataPaginationError: If a full replay page ends within
+            the request's starting second and cannot be continued losslessly.
+        :raises HistoricalDataIncompleteError: If ``strict`` is True and the
+            request reaches ``max_pages`` before natural completion.
+        :raises HistoricalDataConnectionError: If the history plant disconnects
+            while this request is active.
         :raises TimeoutError: If no bar or completion message is received for
             ``idle_timeout`` seconds while waiting.
         """
@@ -167,11 +223,14 @@ class HistoryPlant(BasePlant):
                 "Cannot start another historical tick request with the same "
                 "symbol and exchange while one is already in progress."
             )
+
+        if max_pages < 1:
+            raise ValueError("max_pages must be at least 1")
         
         start_index = self._datetime_to_index(start_time)
         end_index = self._datetime_to_index(end_time)
 
-        self.historical_tick_requests[key] = HistoricalDataRequest(
+        request = HistoricalDataRequest(
             # Request range
             start_index=start_index,
             end_index=end_index,
@@ -184,19 +243,26 @@ class HistoryPlant(BasePlant):
                 bar_type_specifier="1",
                 bar_sub_type=pb.request_tick_bar_replay_pb2.RequestTickBarReplay.BarSubType.REGULAR,
                 time_order=pb.request_tick_bar_replay_pb2.RequestTickBarReplay.TimeOrder.FORWARDS,
+                user_max_count=HISTORICAL_TICK_PAGE_SIZE,
             ),
 
             # Pagination
             page_count=1,
             max_pages=max_pages,
+            strict=strict,
 
             # State
             done=asyncio.Event(),
             data_received=asyncio.Event(),
             data=[],
         )
+        self.historical_tick_requests[key] = request
 
-        await self._request_historical_ticks(key)
+        try:
+            await self._request_historical_ticks(key)
+        except BaseException:
+            self.historical_tick_requests.pop(key, None)
+            raise
 
         if not wait:
             # Historical ticks will still be emitted through `on_historical_tick`,
@@ -206,9 +272,12 @@ class HistoryPlant(BasePlant):
         # Wait until Rithmic sends the completion message, and return ticks.
         try:
             return await self._wait_for_historical_request_completion(
-                request=self.historical_tick_requests[key],
+                request=request,
                 idle_timeout=idle_timeout,
             )
+        except asyncio.CancelledError:
+            self._finish_historical_tick_request(key, request)
+            raise
         finally:
             self.historical_tick_requests.pop(key, None)
 
@@ -323,13 +392,159 @@ class HistoryPlant(BasePlant):
 
         self.logger.debug(f"Requesting page {request.page_count} (start index = {request.start_index}) of historical ticks for {key}")
 
-        await self._send_request(
-            template_id=206,
-            user_msg=key,
-            start_index=request.start_index,
-            finish_index=request.end_index,
-            **request.params,
-        )
+        try:
+            await self._send_request(
+                retry_on_reconnect=False,
+                template_id=206,
+                user_msg=key,
+                start_index=request.start_index,
+                finish_index=request.end_index,
+                **request.params,
+            )
+        except (ConnectionClosedError, ConnectionClosedOK) as error:
+            connection_error = HistoricalDataConnectionError(
+                f"Historical tick replay for {key} was interrupted by "
+                "a connection loss."
+            )
+            self._finish_historical_tick_request(key, request, connection_error)
+            raise connection_error from error
+
+    def _historical_tick_records(self, response, key: str):
+        """Return the tick represented by one replay response."""
+        try:
+            ssboes = list(response.data_bar_ssboe)
+            usecs = list(response.data_bar_usecs)
+        except (TypeError, ValueError) as error:
+            raise HistoricalDataPaginationError(
+                "Historical tick replay returned invalid timestamp fields."
+            ) from error
+        if not ssboes or not usecs:
+            raise HistoricalDataPaginationError(
+                "Historical tick replay returned no timestamp values."
+            )
+        if len(ssboes) != len(usecs):
+            raise HistoricalDataPaginationError(
+                "Historical tick replay returned mismatched timestamp arrays."
+            )
+        if not all(isinstance(ssboe, int) for ssboe in ssboes) or not all(
+            isinstance(usec, int) for usec in usecs
+        ):
+            raise HistoricalDataPaginationError(
+                "Historical tick replay returned non-integer timestamp markers."
+            )
+        if any(ssboe != ssboes[0] for ssboe in ssboes) or any(
+            usec != usecs[0] for usec in usecs
+        ):
+            raise HistoricalDataPaginationError(
+                "Historical tick replay returned non-repeated timestamp values."
+            )
+        if not 0 <= usecs[0] < 1_000_000:
+            raise HistoricalDataPaginationError(
+                "Historical tick replay returned an invalid microsecond marker."
+            )
+
+        # Rithmic repeats each timestamp value; one response represents one tick.
+        ssboe = ssboes[0]
+        usec = usecs[0]
+        data = self._response_to_dict(response)
+        data["_key"] = key
+        try:
+            data["datetime"] = self._ssboe_usecs_to_datetime(ssboe, usec)
+        except (OverflowError, OSError, ValueError) as error:
+            raise HistoricalDataPaginationError(
+                "Historical tick replay returned an invalid timestamp marker."
+            ) from error
+
+        return [(ssboe, usec, data)]
+
+    async def _process_historical_tick_page(
+        self,
+        key: str,
+        request: HistoricalDataRequest,
+    ):
+        page = sorted(request.tick_page, key=lambda tick: (tick[0], tick[1]))
+        request.tick_page.clear()
+
+        if page and page[0][0] < request.start_index:
+            error = HistoricalDataPaginationError(
+                "Historical tick replay returned a timestamp before the "
+                f"requested continuation second {request.start_index}."
+            )
+            self.logger.error(str(error))
+            self._finish_historical_tick_request(key, request, error)
+            return
+
+        if len(page) < HISTORICAL_TICK_PAGE_SIZE:
+            accepted_ticks = page
+            is_complete = True
+        elif len(page) > HISTORICAL_TICK_PAGE_SIZE:
+            error = HistoricalDataPaginationError(
+                "Historical tick replay returned more records than the requested "
+                f"page size of {HISTORICAL_TICK_PAGE_SIZE}."
+            )
+            self.logger.error(str(error))
+            self._finish_historical_tick_request(key, request, error)
+            return
+        else:
+            boundary_second = page[-1][0]
+
+            if (
+                page[0][0] == boundary_second
+                or boundary_second <= request.start_index
+            ):
+                error = HistoricalDataPaginationError(
+                    "Historical tick replay requires more than one page within "
+                    f"second {boundary_second}, but the provider only accepts "
+                    "whole-second continuation bounds."
+                )
+                self.logger.error(str(error))
+                self._finish_historical_tick_request(key, request, error)
+                return
+
+            accepted_ticks = [tick for tick in page if tick[0] < boundary_second]
+            is_complete = False
+
+        try:
+            for _, _, data in accepted_ticks:
+                await self.client.on_historical_tick.call_async(data)
+        except asyncio.CancelledError as error:
+            self._finish_historical_tick_request(key, request, error)
+            raise
+        except Exception as error:
+            self._finish_historical_tick_request(key, request, error)
+            raise
+
+        if is_complete:
+            self.logger.debug(f"Finished downloading historical ticks for {key}")
+            self._finish_historical_tick_request(key, request)
+            return
+
+        if request.reached_max_pages:
+            if request.strict:
+                error = HistoricalDataIncompleteError(
+                    f"Historical tick replay for {key} reached max_pages="
+                    f"{request.max_pages} before completion."
+                )
+                self.logger.error(str(error))
+                self._finish_historical_tick_request(key, request, error)
+            else:
+                self.logger.debug(f"Finished downloading historical ticks for {key}")
+                self._finish_historical_tick_request(key, request)
+            return
+
+        request.page_count += 1
+        request.start_index = boundary_second
+
+        await asyncio.sleep(0.01)
+        if self.historical_tick_requests.get(key) is not request:
+            return
+        try:
+            await self._request_historical_ticks(key)
+        except asyncio.CancelledError as error:
+            self._finish_historical_tick_request(key, request, error)
+            raise
+        except Exception as error:
+            self._finish_historical_tick_request(key, request, error)
 
     async def subscribe_to_time_bar_data(
         self,
@@ -419,37 +634,63 @@ class HistoryPlant(BasePlant):
 
         elif response.template_id == 207:
             # Historical tick bar
-            is_last_bar = response.rp_code == ['0'] or response.rq_handler_rp_code == []
-            key = response.user_msg[0]
+            rp_code = list(response.rp_code)
+            rq_handler_rp_code = list(response.rq_handler_rp_code)
+            user_msg = list(response.user_msg)
+            if not user_msg:
+                error = HistoricalDataPaginationError(
+                    "Historical tick replay response did not include a request key."
+                )
+                self._fail_historical_tick_requests(error)
+                raise error
+            if len(rp_code) > 1 or len(rq_handler_rp_code) > 1:
+                error = HistoricalDataPaginationError(
+                    "Historical tick replay response contained unexpected response "
+                    "markers."
+                )
+                self._fail_historical_tick_requests(error)
+                raise error
+            key = user_msg[0]
 
+            if rp_code and rp_code[0] != "0":
+                if (request := self.historical_tick_requests.get(key)) is not None:
+                    if rp_code[0] == "7":  # Rithmic "no data" response
+                        if request.tick_page:
+                            await self._process_historical_tick_page(key, request)
+                        else:
+                            self._finish_historical_tick_request(key, request)
+                    else:
+                        error = RithmicErrorResponse(
+                            "Rithmic returned an error for historical tick replay: "
+                            f"{rp_code[0]}"
+                        )
+                        self._finish_historical_tick_request(key, request, error)
+                return
+
+            is_last_bar = rp_code == ['0'] or rq_handler_rp_code == []
             if is_last_bar:
                 if (request := self.historical_tick_requests.get(key)) is not None:
-                    if request.is_finished_downloading:
-                        self.logger.debug(f"Finished downloading historical ticks for {key}")
-
-                        self.historical_tick_requests[key].done.set()
-                        self.historical_tick_requests.pop(key, None)
-
-                    else:
-                        # Request the next page of results
-                        next_start_index = request.last_marker + 1
-                        request.last_marker = 0
-                        request.page_count += 1
-                        request.start_index = next_start_index
-
-                        await asyncio.sleep(0.01)
-                        await self._request_historical_ticks(key)
+                    if list(response.data_bar_ssboe) or list(response.data_bar_usecs):
+                        self._finish_historical_tick_request(
+                            key,
+                            request,
+                            HistoricalDataPaginationError(
+                                "Historical tick replay terminal response contained "
+                                "timestamp data."
+                            ),
+                        )
+                        return
+                    await self._process_historical_tick_page(key, request)
 
                 return
 
-            data = self._response_to_dict(response)
-            data["_key"] = key
-            data["datetime"] = self._ssboe_usecs_to_datetime(response.data_bar_ssboe[0], response.data_bar_usecs[0])
-
             if (request := self.historical_tick_requests.get(key)) is not None:
-                request.last_marker = data['data_bar_ssboe'][0]
-
-            await self.client.on_historical_tick.call_async(data)
+                try:
+                    request.tick_page.extend(self._historical_tick_records(response, key))
+                except HistoricalDataPaginationError as error:
+                    self._finish_historical_tick_request(key, request, error)
+                    return
+                request.data_received.set()
 
         elif response.template_id == 250:
             # Time Bar

--- a/async_rithmic/plants/history.py
+++ b/async_rithmic/plants/history.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import asyncio
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 
@@ -12,6 +13,7 @@ from ..exceptions import (
     RithmicErrorResponse,
 )
 from ..enums import SysInfraType, TimeBarType
+from ..objects import HistoricalDataProgress
 from .. import protocol_buffers as pb
 
 HISTORICAL_TICK_PAGE_SIZE = 10_000
@@ -43,6 +45,12 @@ class HistoricalDataRequest:
     last_marker: int = 0
     tick_page: list[tuple[int, int, dict]] = field(default_factory=list)
     error: BaseException | None = None
+    progress_callback: Callable[[HistoricalDataProgress], None] | None = None
+    pages_requested: int = 0
+    rows_received: int = 0
+    page_rows_received: int = 0
+    last_timestamp: datetime | None = None
+    boundary_replay_count: int = 0
 
     @property
     def reached_max_pages(self) -> bool:
@@ -87,6 +95,9 @@ class HistoryPlant(BasePlant):
         key = data["_key"]
         if (request := self.historical_time_bar_requests.get(key)) is not None:
             request.data.append(data)
+            request.rows_received += 1
+            request.page_rows_received += 1
+            request.last_timestamp = data["bar_end_datetime"]
             request.data_received.set()
 
     async def _on_historical_tick(self, data):
@@ -119,6 +130,17 @@ class HistoryPlant(BasePlant):
             request.error = error
         request.done.set()
         self.historical_tick_requests.pop(key, None)
+
+    def _finish_historical_time_bar_request(
+        self,
+        key: str,
+        request: HistoricalDataRequest,
+        error: BaseException | None = None,
+    ):
+        if error is not None and request.error is None:
+            request.error = error
+        request.done.set()
+        self.historical_time_bar_requests.pop(key, None)
 
     def _fail_historical_tick_requests(self, error: BaseException):
         for key, request in list(self.historical_tick_requests.items()):
@@ -179,6 +201,7 @@ class HistoryPlant(BasePlant):
         idle_timeout: float = 5.0,
         max_pages: int = 1_000,
         strict: bool = True,
+        progress_callback: Callable[[HistoricalDataProgress], None] | None = None,
     ):
         """
         Requests historical ticks for a symbol/exchange over a time range.
@@ -202,6 +225,9 @@ class HistoryPlant(BasePlant):
         :param strict: If True, reaching ``max_pages`` before natural replay
             completion raises ``HistoricalDataIncompleteError``. If False, the
             complete seconds received before the limit are returned.
+        :param progress_callback: Optional callback invoked after each page's
+            accepted ticks have been delivered. The callback receives cumulative
+            request progress; an empty successful request emits no progress event.
         :return: A list of historical tick dictionaries when ``wait=True``;
             otherwise ``None``.
         :raises HistoricalDataRequestInProgressError: If another historical tick
@@ -255,6 +281,7 @@ class HistoryPlant(BasePlant):
             done=asyncio.Event(),
             data_received=asyncio.Event(),
             data=[],
+            progress_callback=progress_callback,
         )
         self.historical_tick_requests[key] = request
 
@@ -292,6 +319,7 @@ class HistoryPlant(BasePlant):
         wait: bool = True,
         idle_timeout: float = 5.0,
         max_pages: int = 1_000,
+        progress_callback: Callable[[HistoricalDataProgress], None] | None = None,
     ):
         """
         Requests historical time bars for a symbol/exchange over a time range.
@@ -315,6 +343,9 @@ class HistoryPlant(BasePlant):
             a single replay request without pagination. Values greater than `1` allow
             the client to issue additional replay requests until the returned bars cover
             the requested `end_time`. This handles Rithmic replay truncation.
+        :param progress_callback: Optional callback invoked after each page's
+            accepted bars have been delivered. The callback receives cumulative
+            request progress; an empty successful request emits no progress event.
         :return: A list of historical time bar dictionaries when ``wait=True``;
             otherwise ``None``.
         :raises HistoricalDataRequestInProgressError: If another historical time bar
@@ -356,6 +387,7 @@ class HistoryPlant(BasePlant):
             done=asyncio.Event(),
             data_received=asyncio.Event(),
             data=[],
+            progress_callback=progress_callback,
         )
 
         await self._request_historical_time_bars(key)
@@ -376,6 +408,7 @@ class HistoryPlant(BasePlant):
 
     async def _request_historical_time_bars(self, key: str):
         request: HistoricalDataRequest = self.historical_time_bar_requests[key]
+        request.pages_requested += 1
 
         self.logger.debug(f"Requesting page {request.page_count} (start index = {request.start_index}) of historical time bars for {key}")
 
@@ -389,6 +422,7 @@ class HistoryPlant(BasePlant):
 
     async def _request_historical_ticks(self, key: str):
         request: HistoricalDataRequest = self.historical_tick_requests[key]
+        request.pages_requested += 1
 
         self.logger.debug(f"Requesting page {request.page_count} (start index = {request.start_index}) of historical ticks for {key}")
 
@@ -408,6 +442,34 @@ class HistoryPlant(BasePlant):
             )
             self._finish_historical_tick_request(key, request, connection_error)
             raise connection_error from error
+
+    def _historical_data_progress(self, request: HistoricalDataRequest):
+        return HistoricalDataProgress(
+            pages_requested=request.pages_requested,
+            rows_received=request.rows_received,
+            last_timestamp=request.last_timestamp,
+            boundary_replay_count=request.boundary_replay_count,
+        )
+
+    def _report_historical_time_bar_progress(
+        self,
+        key: str,
+        request: HistoricalDataRequest,
+    ):
+        if request.page_rows_received == 0:
+            return
+
+        if request.progress_callback is not None:
+            try:
+                request.progress_callback(self._historical_data_progress(request))
+            except asyncio.CancelledError as error:
+                self._finish_historical_time_bar_request(key, request, error)
+                raise
+            except Exception as error:
+                self._finish_historical_time_bar_request(key, request, error)
+                raise
+
+        request.page_rows_received = 0
 
     def _historical_tick_records(self, response, key: str):
         """Return the tick represented by one replay response."""
@@ -431,12 +493,6 @@ class HistoryPlant(BasePlant):
         ):
             raise HistoricalDataPaginationError(
                 "Historical tick replay returned non-integer timestamp markers."
-            )
-        if any(ssboe != ssboes[0] for ssboe in ssboes) or any(
-            usec != usecs[0] for usec in usecs
-        ):
-            raise HistoricalDataPaginationError(
-                "Historical tick replay returned non-repeated timestamp values."
             )
         if not 0 <= usecs[0] < 1_000_000:
             raise HistoricalDataPaginationError(
@@ -514,6 +570,26 @@ class HistoryPlant(BasePlant):
             self._finish_historical_tick_request(key, request, error)
             raise
 
+        if accepted_ticks:
+            request.rows_received += len(accepted_ticks)
+            request.last_timestamp = accepted_ticks[-1][2]["datetime"]
+            if request.progress_callback is not None:
+                try:
+                    request.progress_callback(self._historical_data_progress(request))
+                except asyncio.CancelledError as error:
+                    self._finish_historical_tick_request(key, request, error)
+                    raise
+                except Exception as error:
+                    self._finish_historical_tick_request(key, request, error)
+                    raise
+            self.logger.debug(
+                f"Historical tick progress for {key}: "
+                f"pages requested={request.pages_requested}, "
+                f"rows received={request.rows_received}, "
+                f"last timestamp={request.last_timestamp}, "
+                f"boundary replays={request.boundary_replay_count}"
+            )
+
         if is_complete:
             self.logger.debug(f"Finished downloading historical ticks for {key}")
             self._finish_historical_tick_request(key, request)
@@ -532,6 +608,7 @@ class HistoryPlant(BasePlant):
                 self._finish_historical_tick_request(key, request)
             return
 
+        request.boundary_replay_count += 1
         request.page_count += 1
         request.start_index = boundary_second
 
@@ -545,6 +622,7 @@ class HistoryPlant(BasePlant):
             raise
         except Exception as error:
             self._finish_historical_tick_request(key, request, error)
+            raise
 
     async def subscribe_to_time_bar_data(
         self,
@@ -605,6 +683,7 @@ class HistoryPlant(BasePlant):
 
             if is_last_bar:
                 if (request := self.historical_time_bar_requests.get(key)) is not None:
+                    self._report_historical_time_bar_progress(key, request)
                     if request.is_finished_downloading:
                         self.logger.debug(f"Finished downloading historical time bars for {key}")
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import MagicMock, AsyncMock
+from pattern_kit import Event
 
 from async_rithmic.plants import TickerPlant, PnlPlant, OrderPlant
 
@@ -12,6 +13,7 @@ def ticker_plant_mock():
 
     plant.client = MagicMock()
     plant.client.retry_settings = MagicMock(max_retries=1, timeout=3, jitter_range=None)
+    plant.client.on_disconnected = Event()
     return plant
 
 @pytest.fixture

--- a/docs/historical_data.rst
+++ b/docs/historical_data.rst
@@ -52,24 +52,21 @@ The following example fetches historical tick data:
 By default, ``get_historical_tick_data()`` waits until the historical replay is
 complete and returns the collected ticks as a list.
 
-Rithmic historical replay bounds have whole-second resolution. The library floors
-the requested datetimes to whole seconds and explicitly requests pages of 10,000
-ticks. A full page may end partway through its final second, so that final second
-is discarded and replayed from its beginning on the next request. This prevents
-ticks in the same second from being silently skipped. Historical tick callbacks
-are emitted after the current provider page has completed, because only then is
-the final second known to be incomplete.
+Historical replays are paginated automatically. Rithmic typically returns at most
+about 10,000 ticks per page; the client requests additional pages until the
+range is complete, no more data is available, or ``max_pages`` is reached.
+
+Tick replay uses whole-second boundaries, so microseconds in ``start_time`` and
+``end_time`` are rounded down. If a page ends in the middle of a second, the
+client replays that second from its beginning before continuing. This avoids
+skipping ticks that share the page's final second. If one second contains more
+ticks than a page can hold, the client raises ``HistoricalDataPaginationError``
+because the range cannot be continued without risking data loss.
 
 By default, historical tick requests are strict. If ``max_pages`` is reached
-before the provider naturally completes the replay, the request raises
-``HistoricalDataIncompleteError`` instead of returning a partial list as a
-successful result. Set ``strict=False`` only when intentionally accepting a
-partial result.
-
-If a single second contains enough ticks to require more than one page, the
-provider's whole-second bounds cannot express a lossless continuation; the
-request raises ``HistoricalDataPaginationError`` instead of looping or
-returning incomplete data as though it were complete.
+before the replay completes, the request raises ``HistoricalDataIncompleteError``
+instead of returning a partial result. Set ``strict=False`` only when a partial
+result is acceptable.
 
 The ``max_pages`` argument controls how many replay pages can be requested.
 
@@ -85,24 +82,40 @@ progress while waiting for a historical replay to complete.
     )
 
 This is an idle timeout, not a total request timeout. The timer resets whenever a
-provider page or completion message is received.
-
-Because Rithmic cannot represent subsecond replay bounds, nonzero microseconds in
-``start_time`` or ``end_time`` are floored to the containing second. Returned
-ticks should be locally filtered if an application needs a subsecond range.
+page or completion message is received.
 
 If ``wait=False`` is passed, the method sends the replay request and returns
 immediately. Historical ticks are still emitted through the
 ``on_historical_tick`` callback.
 
-Historical callbacks are non-transactional. If a callback raises, the active
-request fails immediately and a waiting caller receives the original callback
-exception; records delivered before the failure are not withdrawn.
+For long replays, pass ``progress_callback`` to receive one update after each
+completed page:
 
-If the history plant connection is interrupted while a historical replay is
-active, the request raises ``HistoricalDataConnectionError`` promptly. The
-library does not resume that replay after reconnecting; callers may retry the
-complete interval after the connection is restored.
+.. code-block:: python
+
+    def on_progress(progress):
+        print(
+            progress.pages_requested,
+            progress.rows_received,
+            progress.last_timestamp,
+        )
+
+    ticks = await client.get_historical_tick_data(
+        ...,
+        progress_callback=on_progress,
+    )
+
+``HistoricalDataProgress`` reports cumulative pages and rows; it is not a
+percentage because the total is not known in advance. ``last_timestamp`` is the
+timestamp of the most recently delivered record. Empty results do not produce a
+progress update. For ticks, ``boundary_replay_count`` tells you how often the
+client had to replay a partial final second; it is always zero for time bars.
+
+If a data or progress callback raises, the replay stops and a waiting call
+receives that exception. Records delivered before the error are not undone.
+
+If the connection is lost during a replay, the request raises
+``HistoricalDataConnectionError`` and is not resumed automatically.
 
 .. code-block:: python
 
@@ -158,19 +171,10 @@ Fetch historical time bars for a symbol over a time range.
 By default, ``get_historical_time_bars()`` waits until the historical replay is
 complete and returns the collected bars as a list.
 
-Rithmic may truncate historical replay responses. In practice, a single replay
-request can return at most about 10,000 bars, even if the requested time range
-contains many more bars. For example, requesting several months of 1-minute bars
-may cover hundreds of thousands of bars, but Rithmic may only return the first
-page of results.
-
-To handle this, ``async_rithmic`` automatically paginates historical time bar
-requests. After each page, it uses the last received bar marker as the starting
-point for the next request and continues until one of the following happens:
-
-- the requested ``end_time`` is reached;
-- Rithmic returns no more data;
-- ``max_pages`` is reached.
+Historical time-bar replays are paginated automatically. Rithmic typically
+returns at most about 10,000 bars per page; the client requests additional pages
+until the range is complete, no more data is available, or ``max_pages`` is
+reached.
 
 The ``max_pages`` argument controls how many replay pages can be requested.
 
@@ -191,6 +195,9 @@ bar or completion message is received.
 If ``wait=False`` is passed, the method sends the replay request and returns
 immediately. Historical bars are still emitted through the
 ``on_historical_time_bar`` callback.
+
+Time-bar requests support the same ``progress_callback`` described above. The
+callback runs after each completed page and reports cumulative bars received.
 
 .. code-block:: python
 

--- a/docs/historical_data.rst
+++ b/docs/historical_data.rst
@@ -52,17 +52,24 @@ The following example fetches historical tick data:
 By default, ``get_historical_tick_data()`` waits until the historical replay is
 complete and returns the collected ticks as a list.
 
-Rithmic may truncate historical replay responses. In practice, a single replay
-request can return at most about 10,000 ticks, even if the requested time range
-contains many more ticks.
+Rithmic historical replay bounds have whole-second resolution. The library floors
+the requested datetimes to whole seconds and explicitly requests pages of 10,000
+ticks. A full page may end partway through its final second, so that final second
+is discarded and replayed from its beginning on the next request. This prevents
+ticks in the same second from being silently skipped. Historical tick callbacks
+are emitted after the current provider page has completed, because only then is
+the final second known to be incomplete.
 
-To handle this, ``async_rithmic`` automatically paginates historical tick
-requests. After each page, it uses the last received tick timestamp as the starting
-point for the next request and continues until one of the following happens:
+By default, historical tick requests are strict. If ``max_pages`` is reached
+before the provider naturally completes the replay, the request raises
+``HistoricalDataIncompleteError`` instead of returning a partial list as a
+successful result. Set ``strict=False`` only when intentionally accepting a
+partial result.
 
-- the requested ``end_time`` is reached;
-- Rithmic returns no more data;
-- ``max_pages`` is reached.
+If a single second contains enough ticks to require more than one page, the
+provider's whole-second bounds cannot express a lossless continuation; the
+request raises ``HistoricalDataPaginationError`` instead of looping or
+returning incomplete data as though it were complete.
 
 The ``max_pages`` argument controls how many replay pages can be requested.
 
@@ -78,11 +85,24 @@ progress while waiting for a historical replay to complete.
     )
 
 This is an idle timeout, not a total request timeout. The timer resets whenever a
-tick or completion message is received.
+provider page or completion message is received.
+
+Because Rithmic cannot represent subsecond replay bounds, nonzero microseconds in
+``start_time`` or ``end_time`` are floored to the containing second. Returned
+ticks should be locally filtered if an application needs a subsecond range.
 
 If ``wait=False`` is passed, the method sends the replay request and returns
 immediately. Historical ticks are still emitted through the
 ``on_historical_tick`` callback.
+
+Historical callbacks are non-transactional. If a callback raises, the active
+request fails immediately and a waiting caller receives the original callback
+exception; records delivered before the failure are not withdrawn.
+
+If the history plant connection is interrupted while a historical replay is
+active, the request raises ``HistoricalDataConnectionError`` promptly. The
+library does not resume that replay after reconnecting; callers may retry the
+complete interval after the connection is restored.
 
 .. code-block:: python
 

--- a/docs/orders.rst
+++ b/docs/orders.rst
@@ -30,6 +30,20 @@ To retrieve a list of currently active orders, use the `list_orders` method:
 
     await client.list_orders()
 
+Get Order
+---------
+
+Use ``get_order()`` to find an order by its user-assigned ``order_id`` or
+Rithmic-assigned ``basket_id``:
+
+.. code-block:: python
+
+    order = await client.get_order(order_id="abc123")
+
+The method searches all accounts unless ``account_id`` is provided. It returns
+the first matching order, or ``None`` if no order is found. It raises
+``InvalidRequestError`` if neither identifier is provided.
+
 Show Order History Summary
 --------------------------
 

--- a/docs/pnl.rst
+++ b/docs/pnl.rst
@@ -1,7 +1,17 @@
-list_account_summary
-
 PNL API
 =========
+
+Account positions
+-----------------
+
+Use ``list_positions()`` to retrieve instrument-level PNL snapshots:
+
+.. code-block:: python
+
+    positions = await client.list_positions(account_id="1234")
+
+The result is a list of position snapshot objects.
+
 
 Account PNL snapshot
 --------------------

--- a/tests/test_connectivity.py
+++ b/tests/test_connectivity.py
@@ -47,6 +47,21 @@ async def test_recv_loop_exits_on_disconnect(ticker_plant_mock):
         await task
 
 
+async def test_recv_loop_notifies_disconnected_listeners(ticker_plant_mock):
+    plant = ticker_plant_mock
+    disconnected = []
+
+    async def on_disconnected(plant_type):
+        disconnected.append(plant_type)
+
+    plant.client.on_disconnected += on_disconnected
+    plant._recv = AsyncMock(side_effect=ConnectionClosedError(rcvd=None, sent=None))
+
+    await plant._recv_loop()
+
+    assert disconnected == [plant.plant_type]
+
+
 async def test_reconnect_loop_restarts_and_calls_login(ticker_plant_mock):
     plant = ticker_plant_mock
     plant.client.reconnection_settings = ReconnectionSettings(

--- a/tests/test_history_plant.py
+++ b/tests/test_history_plant.py
@@ -6,7 +6,7 @@ from pattern_kit import Event
 import pytest
 
 from async_rithmic.plants import HistoryPlant
-from async_rithmic import ReconnectionSettings
+from async_rithmic import HistoricalDataProgress, ReconnectionSettings
 from async_rithmic.exceptions import (
     HistoricalDataConnectionError,
     HistoricalDataIncompleteError,
@@ -92,11 +92,9 @@ def history_plant_mock():
 
 
 async def test_empty_response_returns_empty_list(history_plant_mock):
-    """
-    Bug A: When Rithmic returns only the is_last_bar marker (no data bars),
-    the code used to raise KeyError on .pop(key). Now it returns [].
-    """
+    """Returns an empty time-bar result for a terminal response with no data."""
     plant = history_plant_mock
+    progress = []
     key = f"MNQM6_CME_{int(TimeBarType.MINUTE_BAR)}_1"
 
     # Simulate the is_last_bar marker arriving right after the request is sent
@@ -119,16 +117,19 @@ async def test_empty_response_returns_empty_list(history_plant_mock):
         end_time=datetime(2026, 4, 13, 0, 1),
         bar_type=TimeBarType.MINUTE_BAR,
         bar_type_periods=1,
+        progress_callback=progress.append,
     )
     assert result == []
+    assert progress == []
     # Events dict is cleaned up
     assert key not in plant.historical_time_bar_requests
 
 
 async def test_empty_tick_response_returns_empty_list(history_plant_mock):
-    """Same as Bug A but for tick data."""
+    """Returns an empty tick result without emitting progress for no data."""
     plant = history_plant_mock
     key = f"MNQM6_CME"
+    progress = []
 
     # Simulate the is_last_bar marker arriving right after the request is sent
     async def trigger_empty_response():
@@ -147,8 +148,10 @@ async def test_empty_tick_response_returns_empty_list(history_plant_mock):
     result = await plant.get_historical_tick_data(
         symbol="MNQM6", exchange="CME",
         start_time=datetime(2026, 4, 13, 0), end_time=datetime(2026, 4, 13, 0, 1),
+        progress_callback=progress.append,
     )
     assert result == []
+    assert progress == []
     # Events dict is cleaned up
     assert key not in plant.historical_tick_requests
 
@@ -157,12 +160,14 @@ async def test_empty_tick_response_returns_empty_list(history_plant_mock):
 async def test_partial_tick_page_completes_without_continuation(
     history_plant_mock, monkeypatch
 ):
+    """Reports accepted rows from a partial tick page without continuing."""
     import importlib
 
     history_module = importlib.import_module("async_rithmic.plants.history")
     monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 4)
     plant = history_plant_mock
     key = "MNQM6_CME"
+    progress = []
     calls = configure_tick_responses(
         plant,
         [[
@@ -175,16 +180,119 @@ async def test_partial_tick_page_completes_without_continuation(
         "MNQM6", "CME",
         datetime.fromtimestamp(100, tz=timezone.utc),
         datetime.fromtimestamp(200, tz=timezone.utc),
+        progress_callback=progress.append,
     )
 
     assert [row["id"] for row in result] == ["only", "last"]
+    assert progress == [HistoricalDataProgress(
+        pages_requested=1,
+        rows_received=2,
+        last_timestamp=result[-1]["datetime"],
+        boundary_replay_count=0,
+    )]
     assert len(calls) == 1
     assert key not in plant.historical_tick_requests
+
+
+async def test_tick_progress_is_cumulative_across_pages(
+    history_plant_mock, monkeypatch
+):
+    """Reports cumulative progress across multiple tick pages."""
+    import importlib
+
+    history_module = importlib.import_module("async_rithmic.plants.history")
+    monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 2)
+    plant = history_plant_mock
+    progress = []
+    calls = configure_tick_responses(
+        plant,
+        [
+            [
+                ([100], [100_000], {"id": "first"}),
+                ([101], [100_000], {"id": "boundary"}),
+            ],
+            [([101], [100_000], {"id": "boundary"})],
+        ],
+    )
+
+    result = await plant.get_historical_tick_data(
+        "MNQM6", "CME",
+        datetime.fromtimestamp(100, tz=timezone.utc),
+        datetime.fromtimestamp(200, tz=timezone.utc),
+        progress_callback=progress.append,
+    )
+
+    assert [item.pages_requested for item in progress] == [1, 2]
+    assert [item.rows_received for item in progress] == [1, 2]
+    assert [item.boundary_replay_count for item in progress] == [0, 1]
+    assert progress[-1].last_timestamp == result[-1]["datetime"]
+    assert progress[-1].rows_received == len(result)
+    assert len(calls) == 2
+
+
+async def test_tick_progress_runs_for_wait_false_requests(history_plant_mock):
+    """Emits background tick progress while returning immediately."""
+    plant = history_plant_mock
+    progress = []
+    configure_tick_responses(
+        plant,
+        [[([100], [900_000], {"id": "background"})]],
+    )
+
+    result = await plant.get_historical_tick_data(
+        "MNQM6", "CME",
+        datetime.fromtimestamp(100, tz=timezone.utc),
+        datetime.fromtimestamp(200, tz=timezone.utc),
+        wait=False,
+        progress_callback=progress.append,
+    )
+    await asyncio.sleep(0.02)
+
+    assert result is None
+    assert len(progress) == 1
+    assert progress[0].rows_received == 1
+    assert not plant.historical_tick_requests
+
+
+async def test_progress_callback_failure_is_original_and_stops_pagination(
+    history_plant_mock, monkeypatch
+):
+    """Propagates progress callback failures and stops further pagination."""
+    import importlib
+
+    history_module = importlib.import_module("async_rithmic.plants.history")
+    monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 2)
+    plant = history_plant_mock
+    callback_error = RuntimeError("progress callback failed")
+    progress_callback = MagicMock(side_effect=callback_error)
+    calls = configure_tick_responses(
+        plant,
+        [
+            [
+                ([100], [100_000], {"id": "first"}),
+                ([101], [100_000], {"id": "boundary"}),
+            ],
+            [([101], [100_000], {"id": "replayed"})],
+        ],
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await plant.get_historical_tick_data(
+            "MNQM6", "CME",
+            datetime.fromtimestamp(100, tz=timezone.utc),
+            datetime.fromtimestamp(200, tz=timezone.utc),
+            progress_callback=progress_callback,
+        )
+
+    assert exc_info.value is callback_error
+    assert len(calls) == 1
+    assert not plant.historical_tick_requests
 
 
 async def test_full_tick_page_replays_and_crops_final_second(
     history_plant_mock, monkeypatch
 ):
+    """Crops a full tick page at its boundary second and avoids duplicates."""
     import importlib
 
     history_module = importlib.import_module("async_rithmic.plants.history")
@@ -232,6 +340,7 @@ async def test_full_tick_page_replays_and_crops_final_second(
 async def test_duplicate_timestamps_in_one_response_produce_one_tick(
     history_plant_mock, monkeypatch
 ):
+    """Treats repeated timestamps in one response as one logical tick."""
     import importlib
 
     history_module = importlib.import_module("async_rithmic.plants.history")
@@ -272,11 +381,13 @@ async def test_duplicate_timestamps_in_one_response_produce_one_tick(
 async def test_identical_ticks_from_separate_responses_are_not_deduplicated(
     history_plant_mock, monkeypatch
 ):
+    """Preserves identical ticks from separate responses and counts both."""
     import importlib
 
     history_module = importlib.import_module("async_rithmic.plants.history")
     monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 4)
     plant = history_plant_mock
+    progress = []
     calls = configure_tick_responses(
         plant,
         [[
@@ -297,16 +408,19 @@ async def test_identical_ticks_from_separate_responses_are_not_deduplicated(
         "MNQM6", "CME",
         datetime.fromtimestamp(100, tz=timezone.utc),
         datetime.fromtimestamp(200, tz=timezone.utc),
+        progress_callback=progress.append,
     )
 
     assert len(result) == 2
     assert result[0] == result[1]
+    assert progress[-1].rows_received == 2
     assert len(calls) == 1
 
 
 async def test_tick_page_is_stably_sorted_before_pagination(
     history_plant_mock, monkeypatch
 ):
+    """Sorts tick pages by timestamp before accepting and paginating them."""
     import importlib
 
     history_module = importlib.import_module("async_rithmic.plants.history")
@@ -340,6 +454,7 @@ async def test_tick_page_is_stably_sorted_before_pagination(
 async def test_single_second_overflow_raises_to_public_caller(
     history_plant_mock, monkeypatch
 ):
+    """Raises when a full tick page cannot continue within whole-second bounds."""
     import importlib
 
     history_module = importlib.import_module("async_rithmic.plants.history")
@@ -369,11 +484,13 @@ async def test_single_second_overflow_raises_to_public_caller(
 async def test_max_pages_in_strict_mode_fails_without_partial_success(
     history_plant_mock, monkeypatch
 ):
+    """Raises on max-pages exhaustion in strict mode after accepted progress."""
     import importlib
 
     history_module = importlib.import_module("async_rithmic.plants.history")
     monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 4)
     plant = history_plant_mock
+    progress = []
     calls = configure_tick_responses(
         plant,
         [[
@@ -390,15 +507,18 @@ async def test_max_pages_in_strict_mode_fails_without_partial_success(
             datetime.fromtimestamp(100, tz=timezone.utc),
             datetime.fromtimestamp(200, tz=timezone.utc),
             max_pages=1,
+            progress_callback=progress.append,
         )
 
     assert len(calls) == 1
+    assert progress[-1].rows_received == 1
     assert not plant.historical_tick_requests
 
 
 async def test_max_pages_can_explicitly_allow_a_partial_result(
     history_plant_mock, monkeypatch
 ):
+    """Returns complete rows before max-pages exhaustion when strict mode is off."""
     import importlib
 
     history_module = importlib.import_module("async_rithmic.plants.history")
@@ -429,6 +549,7 @@ async def test_max_pages_can_explicitly_allow_a_partial_result(
 async def test_invalid_max_pages_fails_before_provider_io(
     history_plant_mock, max_pages
 ):
+    """Rejects invalid max-pages values before sending a provider request."""
     plant = history_plant_mock
 
     with pytest.raises(ValueError, match="max_pages"):
@@ -446,8 +567,10 @@ async def test_invalid_max_pages_fails_before_provider_io(
 async def test_historical_callback_failure_completes_request_with_original_error(
     history_plant_mock
 ):
+    """Propagates historical callback failures without progress or leaked state."""
     plant = history_plant_mock
     callback_error = RuntimeError("historical callback failed")
+    progress = []
 
     async def failing_callback(data):
         raise callback_error
@@ -463,15 +586,18 @@ async def test_historical_callback_failure_completes_request_with_original_error
             "MNQM6", "CME",
             datetime.fromtimestamp(100, tz=timezone.utc),
             datetime.fromtimestamp(200, tz=timezone.utc),
+            progress_callback=progress.append,
         )
 
     assert exc_info.value is callback_error
+    assert progress == []
     assert not plant.historical_tick_requests
 
 
 async def test_history_disconnect_fails_active_request_without_waiting_for_timeout(
     history_plant_mock
 ):
+    """Fails an active tick replay promptly when the history connection disconnects."""
     plant = history_plant_mock
     plant._send_request = AsyncMock(return_value=None)
 
@@ -497,6 +623,7 @@ async def test_history_disconnect_fails_active_request_without_waiting_for_timeo
 async def test_new_historical_request_can_start_after_disconnect(
     history_plant_mock
 ):
+    """Allows a new tick replay after a disconnected request has failed."""
     plant = history_plant_mock
     plant._send_request = AsyncMock(return_value=None)
 
@@ -531,6 +658,7 @@ async def test_new_historical_request_can_start_after_disconnect(
 async def test_reconnect_does_not_resume_failed_historical_request(
     history_plant_mock
 ):
+    """Does not resume a failed replay after reconnecting and permits a new one."""
     plant = history_plant_mock
     plant._send_request = AsyncMock(return_value=None)
     plant.client.reconnection_settings = ReconnectionSettings(
@@ -581,6 +709,7 @@ async def test_reconnect_does_not_resume_failed_historical_request(
 
 
 async def test_cancelled_historical_request_remains_cancelled(history_plant_mock):
+    """Preserves caller cancellation and cleans up the active tick replay."""
     plant = history_plant_mock
     plant._send_request = AsyncMock(return_value=None)
 
@@ -604,6 +733,7 @@ async def test_cancelled_historical_request_remains_cancelled(history_plant_mock
 async def test_continuation_timestamp_before_boundary_fails_closed(
     history_plant_mock, monkeypatch
 ):
+    """Rejects a continuation page containing a timestamp before its boundary."""
     import importlib
 
     history_module = importlib.import_module("async_rithmic.plants.history")
@@ -630,38 +760,10 @@ async def test_continuation_timestamp_before_boundary_fails_closed(
     assert not plant.historical_tick_requests
 
 
-async def test_malformed_tick_timestamp_arrays_fail_closed(history_plant_mock):
-    plant = history_plant_mock
-    key = "MNQM6_CME"
-    plant._response_to_dict = lambda response: {}
-
-    async def fake_send_request(**kwargs):
-        await plant._process_response(
-            MagicMock(
-                template_id=207,
-                rp_code=[],
-                rq_handler_rp_code=["data"],
-                user_msg=[key],
-                data_bar_ssboe=[100, 101],
-                data_bar_usecs=[900_000, 900_000],
-            )
-        )
-
-    plant._send_request = AsyncMock(side_effect=fake_send_request)
-
-    with pytest.raises(HistoricalDataPaginationError, match="non-repeated"):
-        await plant.get_historical_tick_data(
-            "MNQM6", "CME",
-            datetime.fromtimestamp(100, tz=timezone.utc),
-            datetime.fromtimestamp(200, tz=timezone.utc),
-        )
-
-    assert not plant.historical_tick_requests
-
-
 async def test_empty_tick_continuation_completes_without_duplicate_callbacks(
     history_plant_mock, monkeypatch
 ):
+    """Completes an empty continuation without duplicating delivered callbacks."""
     import importlib
 
     history_module = importlib.import_module("async_rithmic.plants.history")
@@ -693,6 +795,7 @@ async def test_empty_tick_continuation_completes_without_duplicate_callbacks(
 async def test_tick_provider_error_does_not_emit_buffered_partial_page(
     history_plant_mock
 ):
+    """Discards buffered ticks when the provider reports a page error."""
     plant = history_plant_mock
     key = "MNQM6_CME"
     callback_ids = []
@@ -735,6 +838,7 @@ async def test_tick_provider_error_does_not_emit_buffered_partial_page(
 async def test_tick_continuation_send_error_completes_and_cleans_up(
     history_plant_mock, monkeypatch
 ):
+    """Propagates continuation-send failures and cleans up the tick replay."""
     import importlib
 
     history_module = importlib.import_module("async_rithmic.plants.history")
@@ -773,6 +877,7 @@ async def test_tick_continuation_send_error_completes_and_cleans_up(
 
 
 async def test_subsecond_tick_bounds_are_floored(history_plant_mock):
+    """Floors subsecond tick bounds before constructing the provider request."""
     plant = history_plant_mock
     await plant.get_historical_tick_data(
         "MNQM6", "CME",
@@ -793,6 +898,7 @@ async def test_subsecond_tick_bounds_are_floored(history_plant_mock):
 async def test_repeated_full_page_fails_instead_of_looping(
     history_plant_mock, monkeypatch
 ):
+    """Stops repeated full pages instead of looping and preserves accepted rows."""
     import importlib
 
     history_module = importlib.import_module("async_rithmic.plants.history")
@@ -825,10 +931,7 @@ async def test_repeated_full_page_fails_instead_of_looping(
 
 
 async def test_concurrent_different_symbols(history_plant_mock):
-    """
-    Bug B: Two concurrent requests used to share one event. The first response
-    would wake the second caller prematurely. Now each request has its own event.
-    """
+    """Keeps concurrent time-bar requests isolated by symbol."""
     plant = history_plant_mock
 
     async def fire_responses(data_rows):
@@ -884,14 +987,9 @@ async def test_concurrent_different_symbols(history_plant_mock):
     assert result_b[0]["y"] == 1
 
 async def test_historical_time_bar_pagination(history_plant_mock):
-    """
-    When Rithmic truncates a historical time bar replay, the client should
-    request additional pages until the returned bars cover the requested end_time.
-
-    Rithmic seems to label time bars by end timestamp. So a request covering 10:00 to
-    10:04 can return bars labeled 10:01, 10:02, 10:03, 10:04, 10:05.
-    """
+    """Requests more time-bar pages until the requested end boundary is covered."""
     plant = history_plant_mock
+    progress = []
 
     symbol = "MNQM6"
     exchange = "CME"
@@ -975,6 +1073,7 @@ async def test_historical_time_bar_pagination(history_plant_mock):
         bar_type=bar_type,
         bar_type_periods=bar_type_periods,
         max_pages=5,
+        progress_callback=progress.append,
     )
 
     assert [row["marker"] for row in result] == [
@@ -986,6 +1085,20 @@ async def test_historical_time_bar_pagination(history_plant_mock):
     ]
 
     assert [row["page"] for row in result] == [1, 1, 2, 2, 2]
+    assert progress == [
+        HistoricalDataProgress(
+            pages_requested=1,
+            rows_received=2,
+            last_timestamp=result[1]["bar_end_datetime"],
+            boundary_replay_count=0,
+        ),
+        HistoricalDataProgress(
+            pages_requested=2,
+            rows_received=5,
+            last_timestamp=result[-1]["bar_end_datetime"],
+            boundary_replay_count=0,
+        ),
+    ]
 
     # One request for the first page, one request for the second page.
     assert plant._send_request.await_count == 2
@@ -1008,3 +1121,119 @@ async def test_historical_time_bar_pagination(history_plant_mock):
     # next_start_index = request.last_marker + 1
     assert second_call["start_index"] == 1777644120 + 1
     assert second_call["finish_index"] == 1777644240
+
+
+async def test_time_bar_progress_runs_for_wait_false_requests(history_plant_mock):
+    """Emits background time-bar progress while returning immediately."""
+    plant = history_plant_mock
+    symbol = "MNQM6"
+    exchange = "CME"
+    bar_type = TimeBarType.MINUTE_BAR
+    bar_type_periods = 1
+    key = f"{symbol}_{exchange}_{bar_type}_{bar_type_periods}"
+    progress = []
+
+    async def emit_response():
+        await asyncio.sleep(0.01)
+        plant._response_to_dict = MagicMock(return_value={"marker": 200})
+        await plant._process_response(
+            MagicMock(
+                template_id=203,
+                rp_code=[],
+                rq_handler_rp_code=["data"],
+                user_msg=[key],
+            )
+        )
+        await plant._process_response(
+            MagicMock(
+                template_id=203,
+                rp_code=["0"],
+                rq_handler_rp_code=[],
+                user_msg=[key],
+            )
+        )
+
+    async def fake_send_request(**kwargs):
+        task = asyncio.create_task(emit_response())
+        task.add_done_callback(
+            lambda task: None if task.cancelled() else task.exception()
+        )
+
+    plant._send_request = AsyncMock(side_effect=fake_send_request)
+
+    result = await plant.get_historical_time_bars(
+        symbol,
+        exchange,
+        datetime.fromtimestamp(100, tz=timezone.utc),
+        datetime.fromtimestamp(200, tz=timezone.utc),
+        bar_type,
+        bar_type_periods,
+        wait=False,
+        progress_callback=progress.append,
+    )
+    await asyncio.sleep(0.02)
+
+    assert result is None
+    assert progress == [HistoricalDataProgress(
+        pages_requested=1,
+        rows_received=1,
+        last_timestamp=datetime.fromtimestamp(200),
+        boundary_replay_count=0,
+    )]
+    assert not plant.historical_time_bar_requests
+
+
+async def test_time_bar_progress_callback_failure_cleans_up_request(
+    history_plant_mock,
+):
+    """Propagates time-bar progress failures and cleans up the request."""
+    plant = history_plant_mock
+    symbol = "MNQM6"
+    exchange = "CME"
+    bar_type = TimeBarType.MINUTE_BAR
+    bar_type_periods = 1
+    key = f"{symbol}_{exchange}_{bar_type}_{bar_type_periods}"
+    callback_error = RuntimeError("time-bar progress failed")
+    progress_callback = MagicMock(side_effect=callback_error)
+
+    async def emit_response():
+        await asyncio.sleep(0.01)
+        plant._response_to_dict = MagicMock(return_value={"marker": 200})
+        await plant._process_response(
+            MagicMock(
+                template_id=203,
+                rp_code=[],
+                rq_handler_rp_code=["data"],
+                user_msg=[key],
+            )
+        )
+        await plant._process_response(
+            MagicMock(
+                template_id=203,
+                rp_code=["0"],
+                rq_handler_rp_code=[],
+                user_msg=[key],
+            )
+        )
+
+    async def fake_send_request(**kwargs):
+        task = asyncio.create_task(emit_response())
+        task.add_done_callback(
+            lambda task: None if task.cancelled() else task.exception()
+        )
+
+    plant._send_request = AsyncMock(side_effect=fake_send_request)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await plant.get_historical_time_bars(
+            symbol,
+            exchange,
+            datetime.fromtimestamp(100, tz=timezone.utc),
+            datetime.fromtimestamp(200, tz=timezone.utc),
+            bar_type,
+            bar_type_periods,
+            progress_callback=progress_callback,
+        )
+
+    assert exc_info.value is callback_error
+    assert not plant.historical_time_bar_requests

--- a/tests/test_history_plant.py
+++ b/tests/test_history_plant.py
@@ -6,13 +6,80 @@ from pattern_kit import Event
 import pytest
 
 from async_rithmic.plants import HistoryPlant
+from async_rithmic import ReconnectionSettings
+from async_rithmic.exceptions import (
+    HistoricalDataConnectionError,
+    HistoricalDataIncompleteError,
+    HistoricalDataPaginationError,
+    RithmicErrorResponse,
+)
 from async_rithmic.enums import TimeBarType
+
+
+def tick_response(key, ssboes, usecs, payload=None, terminal=False):
+    if not terminal:
+        # A replay response represents one tick, with duplicated timestamp fields.
+        ssboes = [ssboes[0], ssboes[0]]
+        usecs = [usecs[0], usecs[0]]
+
+    response = MagicMock(
+        template_id=207,
+        rp_code=["0"] if terminal else [],
+        rq_handler_rp_code=[] if terminal else ["data"],
+        user_msg=[key],
+        data_bar_ssboe=ssboes,
+        data_bar_usecs=usecs,
+        data_bar_seq_num=[],
+    )
+    response.payload = payload or {}
+    return response
+
+
+def configure_tick_responses(plant, pages):
+    def response_to_dict(response):
+        data = response.payload.copy()
+        if response.data_bar_ssboe:
+            data.setdefault("data_bar_ssboe", [response.data_bar_ssboe[0]])
+        if response.data_bar_usecs:
+            data.setdefault("data_bar_usecs", [response.data_bar_usecs[0]])
+        return data
+
+    plant._response_to_dict = response_to_dict
+    calls = []
+
+    async def emit_page(page, key):
+        for ssboes, usecs, payload in page:
+            await plant._process_response(
+                tick_response(
+                    key,
+                    ssboes,
+                    usecs,
+                    payload,
+                )
+            )
+        await plant._process_response(
+            tick_response(key, [], [], terminal=True)
+        )
+
+    def consume_task_exception(task):
+        if not task.cancelled():
+            task.exception()
+
+    async def fake_send_request(**kwargs):
+        calls.append(kwargs)
+        page = pages[len(calls) - 1]
+        task = asyncio.create_task(emit_page(page, kwargs["user_msg"]))
+        task.add_done_callback(consume_task_exception)
+
+    plant._send_request = AsyncMock(side_effect=fake_send_request)
+    return calls
 
 
 @pytest.fixture
 def history_plant_mock():
     client = MagicMock()
     client.retry_settings = MagicMock(max_retries=1, timeout=3, jitter_range=None)
+    client.on_disconnected = Event()
     client.on_historical_time_bar = Event()
     client.on_historical_tick = Event()
 
@@ -69,7 +136,8 @@ async def test_empty_tick_response_returns_empty_list(history_plant_mock):
         await plant._process_response(
             MagicMock(
                 template_id=207,
-                rp_code=['0'],
+                rp_code=[],
+                rq_handler_rp_code=[],
                 user_msg=[key]
             )
         )
@@ -84,6 +152,676 @@ async def test_empty_tick_response_returns_empty_list(history_plant_mock):
     # Events dict is cleaned up
     assert key not in plant.historical_tick_requests
 
+
+
+async def test_partial_tick_page_completes_without_continuation(
+    history_plant_mock, monkeypatch
+):
+    import importlib
+
+    history_module = importlib.import_module("async_rithmic.plants.history")
+    monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 4)
+    plant = history_plant_mock
+    key = "MNQM6_CME"
+    calls = configure_tick_responses(
+        plant,
+        [[
+            ([100], [900_000], {"id": "only"}),
+            ([100], [950_000], {"id": "last"}),
+        ]],
+    )
+
+    result = await plant.get_historical_tick_data(
+        "MNQM6", "CME",
+        datetime.fromtimestamp(100, tz=timezone.utc),
+        datetime.fromtimestamp(200, tz=timezone.utc),
+    )
+
+    assert [row["id"] for row in result] == ["only", "last"]
+    assert len(calls) == 1
+    assert key not in plant.historical_tick_requests
+
+
+async def test_full_tick_page_replays_and_crops_final_second(
+    history_plant_mock, monkeypatch
+):
+    import importlib
+
+    history_module = importlib.import_module("async_rithmic.plants.history")
+    monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 4)
+    plant = history_plant_mock
+    callback_ids = []
+
+    async def on_tick(data):
+        callback_ids.append(data["id"])
+
+    plant.client.on_historical_tick += on_tick
+    calls = configure_tick_responses(
+        plant,
+        [
+            [
+                ([100], [900_000], {"id": "safe"}),
+                ([101], [0], {"id": "boundary-zero"}),
+                ([101], [100_000], {"id": "boundary-a"}),
+                ([101], [200_000], {"id": "boundary-b"}),
+            ],
+            [
+                ([101], [0], {"id": "boundary-zero"}),
+                ([101], [100_000], {"id": "boundary-a"}),
+                ([101], [200_000], {"id": "boundary-b"}),
+            ],
+        ],
+    )
+
+    result = await plant.get_historical_tick_data(
+        "MNQM6", "CME",
+        datetime.fromtimestamp(100, tz=timezone.utc),
+        datetime.fromtimestamp(200, tz=timezone.utc),
+    )
+
+    assert [row["id"] for row in result] == [
+        "safe", "boundary-zero", "boundary-a", "boundary-b"
+    ]
+    assert calls[1]["start_index"] == 101
+    assert sum(row["id"] == "boundary-zero" for row in result) == 1
+    assert sum(row["id"] == "boundary-a" for row in result) == 1
+    assert sum(row["id"] == "boundary-b" for row in result) == 1
+    assert callback_ids == [row["id"] for row in result]
+
+
+async def test_duplicate_timestamps_in_one_response_produce_one_tick(
+    history_plant_mock, monkeypatch
+):
+    import importlib
+
+    history_module = importlib.import_module("async_rithmic.plants.history")
+    monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 4)
+    plant = history_plant_mock
+    callback_records = []
+
+    async def on_tick(data):
+        callback_records.append(data)
+
+    plant.client.on_historical_tick += on_tick
+    configure_tick_responses(
+        plant,
+        [[
+            ([101, 101], [200_000, 200_000], {
+                "data_bar_seq_num": ["tick-sequence"],
+                "price": 101.5,
+                "quantity": 2,
+            }),
+        ]],
+    )
+
+    result = await plant.get_historical_tick_data(
+        "MNQM6", "CME",
+        datetime.fromtimestamp(100, tz=timezone.utc),
+        datetime.fromtimestamp(200, tz=timezone.utc),
+    )
+
+    assert len(result) == 1
+    assert result[0]["data_bar_seq_num"] == ["tick-sequence"]
+    assert result[0]["price"] == 101.5
+    assert result[0]["quantity"] == 2
+    assert result[0]["data_bar_ssboe"] == [101]
+    assert result[0]["data_bar_usecs"] == [200_000]
+    assert callback_records == result
+
+
+async def test_identical_ticks_from_separate_responses_are_not_deduplicated(
+    history_plant_mock, monkeypatch
+):
+    import importlib
+
+    history_module = importlib.import_module("async_rithmic.plants.history")
+    monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 4)
+    plant = history_plant_mock
+    calls = configure_tick_responses(
+        plant,
+        [[
+            ([100], [500_000], {
+                "price": 100.25,
+                "quantity": 2,
+                "side": "B",
+            }),
+            ([100], [500_000], {
+                "price": 100.25,
+                "quantity": 2,
+                "side": "B",
+            }),
+        ]],
+    )
+
+    result = await plant.get_historical_tick_data(
+        "MNQM6", "CME",
+        datetime.fromtimestamp(100, tz=timezone.utc),
+        datetime.fromtimestamp(200, tz=timezone.utc),
+    )
+
+    assert len(result) == 2
+    assert result[0] == result[1]
+    assert len(calls) == 1
+
+
+async def test_tick_page_is_stably_sorted_before_pagination(
+    history_plant_mock, monkeypatch
+):
+    import importlib
+
+    history_module = importlib.import_module("async_rithmic.plants.history")
+    monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 4)
+    plant = history_plant_mock
+    calls = configure_tick_responses(
+        plant,
+        [
+            [
+                ([101], [200_000], {"id": "latest"}),
+                ([100], [500_000], {"id": "first"}),
+                ([100], [500_000], {"id": "second"}),
+                ([100], [900_000], {"id": "middle"}),
+            ],
+            [([101], [200_000], {"id": "latest"})],
+        ],
+    )
+
+    result = await plant.get_historical_tick_data(
+        "MNQM6", "CME",
+        datetime.fromtimestamp(100, tz=timezone.utc),
+        datetime.fromtimestamp(200, tz=timezone.utc),
+    )
+
+    assert [row["id"] for row in result] == [
+        "first", "second", "middle", "latest"
+    ]
+    assert calls[1]["start_index"] == 101
+
+
+async def test_single_second_overflow_raises_to_public_caller(
+    history_plant_mock, monkeypatch
+):
+    import importlib
+
+    history_module = importlib.import_module("async_rithmic.plants.history")
+    monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 4)
+    plant = history_plant_mock
+    calls = configure_tick_responses(
+        plant,
+        [[
+            ([100], [100_000], {"id": "a"}),
+            ([100], [200_000], {"id": "b"}),
+            ([100], [300_000], {"id": "c"}),
+            ([100], [400_000], {"id": "d"}),
+        ]],
+    )
+
+    with pytest.raises(HistoricalDataPaginationError, match="more than one page"):
+        await plant.get_historical_tick_data(
+            "MNQM6", "CME",
+            datetime.fromtimestamp(100, tz=timezone.utc),
+            datetime.fromtimestamp(200, tz=timezone.utc),
+        )
+
+    assert len(calls) == 1
+    assert not plant.historical_tick_requests
+
+
+async def test_max_pages_in_strict_mode_fails_without_partial_success(
+    history_plant_mock, monkeypatch
+):
+    import importlib
+
+    history_module = importlib.import_module("async_rithmic.plants.history")
+    monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 4)
+    plant = history_plant_mock
+    calls = configure_tick_responses(
+        plant,
+        [[
+            ([100], [900_000], {"id": "safe"}),
+            ([101], [0], {"id": "boundary-zero"}),
+            ([101], [100_000], {"id": "boundary-a"}),
+            ([101], [200_000], {"id": "boundary-b"}),
+        ]],
+    )
+
+    with pytest.raises(HistoricalDataIncompleteError):
+        await plant.get_historical_tick_data(
+            "MNQM6", "CME",
+            datetime.fromtimestamp(100, tz=timezone.utc),
+            datetime.fromtimestamp(200, tz=timezone.utc),
+            max_pages=1,
+        )
+
+    assert len(calls) == 1
+    assert not plant.historical_tick_requests
+
+
+async def test_max_pages_can_explicitly_allow_a_partial_result(
+    history_plant_mock, monkeypatch
+):
+    import importlib
+
+    history_module = importlib.import_module("async_rithmic.plants.history")
+    monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 4)
+    plant = history_plant_mock
+    configure_tick_responses(
+        plant,
+        [[
+            ([100], [900_000], {"id": "safe"}),
+            ([101], [0], {"id": "boundary-zero"}),
+            ([101], [100_000], {"id": "boundary-a"}),
+            ([101], [200_000], {"id": "boundary-b"}),
+        ]],
+    )
+
+    result = await plant.get_historical_tick_data(
+        "MNQM6", "CME",
+        datetime.fromtimestamp(100, tz=timezone.utc),
+        datetime.fromtimestamp(200, tz=timezone.utc),
+        max_pages=1,
+        strict=False,
+    )
+
+    assert [row["id"] for row in result] == ["safe"]
+
+
+@pytest.mark.parametrize("max_pages", [0, -1])
+async def test_invalid_max_pages_fails_before_provider_io(
+    history_plant_mock, max_pages
+):
+    plant = history_plant_mock
+
+    with pytest.raises(ValueError, match="max_pages"):
+        await plant.get_historical_tick_data(
+            "MNQM6", "CME",
+            datetime.fromtimestamp(100, tz=timezone.utc),
+            datetime.fromtimestamp(200, tz=timezone.utc),
+            max_pages=max_pages,
+        )
+
+    plant._send_request.assert_not_awaited()
+    assert not plant.historical_tick_requests
+
+
+async def test_historical_callback_failure_completes_request_with_original_error(
+    history_plant_mock
+):
+    plant = history_plant_mock
+    callback_error = RuntimeError("historical callback failed")
+
+    async def failing_callback(data):
+        raise callback_error
+
+    plant.client.on_historical_tick += failing_callback
+    configure_tick_responses(
+        plant,
+        [[([100], [900_000], {"id": "delivered-before-failure"})]],
+    )
+
+    with pytest.raises(RuntimeError, match="historical callback failed") as exc_info:
+        await plant.get_historical_tick_data(
+            "MNQM6", "CME",
+            datetime.fromtimestamp(100, tz=timezone.utc),
+            datetime.fromtimestamp(200, tz=timezone.utc),
+        )
+
+    assert exc_info.value is callback_error
+    assert not plant.historical_tick_requests
+
+
+async def test_history_disconnect_fails_active_request_without_waiting_for_timeout(
+    history_plant_mock
+):
+    plant = history_plant_mock
+    plant._send_request = AsyncMock(return_value=None)
+
+    request_task = asyncio.create_task(
+        plant.get_historical_tick_data(
+            "MNQM6", "CME",
+            datetime.fromtimestamp(100, tz=timezone.utc),
+            datetime.fromtimestamp(200, tz=timezone.utc),
+            idle_timeout=30,
+        )
+    )
+    await asyncio.sleep(0)
+    assert plant.historical_tick_requests
+
+    await plant.client.on_disconnected.call_async(plant.plant_type)
+
+    with pytest.raises(HistoricalDataConnectionError):
+        await request_task
+
+    assert not plant.historical_tick_requests
+
+
+async def test_new_historical_request_can_start_after_disconnect(
+    history_plant_mock
+):
+    plant = history_plant_mock
+    plant._send_request = AsyncMock(return_value=None)
+
+    request_task = asyncio.create_task(
+        plant.get_historical_tick_data(
+            "MNQM6", "CME",
+            datetime.fromtimestamp(100, tz=timezone.utc),
+            datetime.fromtimestamp(200, tz=timezone.utc),
+            idle_timeout=30,
+        )
+    )
+    await asyncio.sleep(0)
+    await plant.client.on_disconnected.call_async(plant.plant_type)
+
+    with pytest.raises(HistoricalDataConnectionError):
+        await request_task
+
+    configure_tick_responses(
+        plant,
+        [[([100], [900_000], {"id": "after-reconnect"})]],
+    )
+    result = await plant.get_historical_tick_data(
+        "MNQM6", "CME",
+        datetime.fromtimestamp(100, tz=timezone.utc),
+        datetime.fromtimestamp(200, tz=timezone.utc),
+    )
+
+    assert [row["id"] for row in result] == ["after-reconnect"]
+    assert not plant.historical_tick_requests
+
+
+async def test_reconnect_does_not_resume_failed_historical_request(
+    history_plant_mock
+):
+    plant = history_plant_mock
+    plant._send_request = AsyncMock(return_value=None)
+    plant.client.reconnection_settings = ReconnectionSettings(
+        max_retries=1,
+        backoff_type="constant",
+        interval=0,
+    )
+    plant._connect = AsyncMock()
+    plant._start_io_tasks = AsyncMock()
+    plant._stop_io_tasks = AsyncMock()
+    plant._login = AsyncMock()
+
+    request_task = asyncio.create_task(
+        plant.get_historical_tick_data(
+            "MNQM6", "CME",
+            datetime.fromtimestamp(100, tz=timezone.utc),
+            datetime.fromtimestamp(200, tz=timezone.utc),
+            idle_timeout=30,
+        )
+    )
+    await asyncio.sleep(0)
+    await plant.client.on_disconnected.call_async(plant.plant_type)
+
+    with pytest.raises(HistoricalDataConnectionError):
+        await request_task
+
+    reconnect_task = asyncio.create_task(plant._reconnect_loop())
+    plant._disconnect_event.set()
+    await asyncio.sleep(0.01)
+    reconnect_task.cancel()
+    await reconnect_task
+
+    assert plant._send_request.await_count == 1
+    assert not plant.historical_tick_requests
+
+    configure_tick_responses(
+        plant,
+        [[([100], [900_000], {"id": "after-reconnect"})]],
+    )
+    result = await plant.get_historical_tick_data(
+        "MNQM6", "CME",
+        datetime.fromtimestamp(100, tz=timezone.utc),
+        datetime.fromtimestamp(200, tz=timezone.utc),
+    )
+
+    assert [row["id"] for row in result] == ["after-reconnect"]
+    assert not plant.historical_tick_requests
+
+
+async def test_cancelled_historical_request_remains_cancelled(history_plant_mock):
+    plant = history_plant_mock
+    plant._send_request = AsyncMock(return_value=None)
+
+    request_task = asyncio.create_task(
+        plant.get_historical_tick_data(
+            "MNQM6", "CME",
+            datetime.fromtimestamp(100, tz=timezone.utc),
+            datetime.fromtimestamp(200, tz=timezone.utc),
+            idle_timeout=30,
+        )
+    )
+    await asyncio.sleep(0)
+    request_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await request_task
+
+    assert not plant.historical_tick_requests
+
+
+async def test_continuation_timestamp_before_boundary_fails_closed(
+    history_plant_mock, monkeypatch
+):
+    import importlib
+
+    history_module = importlib.import_module("async_rithmic.plants.history")
+    monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 2)
+    plant = history_plant_mock
+    configure_tick_responses(
+        plant,
+        [
+            [
+                ([100], [900_000], {"id": "safe"}),
+                ([101], [0], {"id": "boundary"}),
+            ],
+            [([100], [950_000], {"id": "stale"})],
+        ],
+    )
+
+    with pytest.raises(HistoricalDataPaginationError, match="before"):
+        await plant.get_historical_tick_data(
+            "MNQM6", "CME",
+            datetime.fromtimestamp(100, tz=timezone.utc),
+            datetime.fromtimestamp(200, tz=timezone.utc),
+        )
+
+    assert not plant.historical_tick_requests
+
+
+async def test_malformed_tick_timestamp_arrays_fail_closed(history_plant_mock):
+    plant = history_plant_mock
+    key = "MNQM6_CME"
+    plant._response_to_dict = lambda response: {}
+
+    async def fake_send_request(**kwargs):
+        await plant._process_response(
+            MagicMock(
+                template_id=207,
+                rp_code=[],
+                rq_handler_rp_code=["data"],
+                user_msg=[key],
+                data_bar_ssboe=[100, 101],
+                data_bar_usecs=[900_000, 900_000],
+            )
+        )
+
+    plant._send_request = AsyncMock(side_effect=fake_send_request)
+
+    with pytest.raises(HistoricalDataPaginationError, match="non-repeated"):
+        await plant.get_historical_tick_data(
+            "MNQM6", "CME",
+            datetime.fromtimestamp(100, tz=timezone.utc),
+            datetime.fromtimestamp(200, tz=timezone.utc),
+        )
+
+    assert not plant.historical_tick_requests
+
+
+async def test_empty_tick_continuation_completes_without_duplicate_callbacks(
+    history_plant_mock, monkeypatch
+):
+    import importlib
+
+    history_module = importlib.import_module("async_rithmic.plants.history")
+    monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 2)
+    plant = history_plant_mock
+    callback_ids = []
+
+    async def on_tick(data):
+        callback_ids.append(data["id"])
+
+    plant.client.on_historical_tick += on_tick
+    calls = configure_tick_responses(
+        plant,
+        [[([100], [900_000], {"id": "safe"}), ([101], [0], {"id": "boundary"})], []],
+    )
+
+    result = await plant.get_historical_tick_data(
+        "MNQM6", "CME",
+        datetime.fromtimestamp(100, tz=timezone.utc),
+        datetime.fromtimestamp(200, tz=timezone.utc),
+    )
+
+    assert [row["id"] for row in result] == ["safe"]
+    assert callback_ids == ["safe"]
+    assert len(calls) == 2
+    assert calls[1]["start_index"] == 101
+
+
+async def test_tick_provider_error_does_not_emit_buffered_partial_page(
+    history_plant_mock
+):
+    plant = history_plant_mock
+    key = "MNQM6_CME"
+    callback_ids = []
+    calls = []
+
+    async def on_tick(data):
+        callback_ids.append(data["id"])
+
+    plant.client.on_historical_tick += on_tick
+    plant._response_to_dict = lambda response: response.payload.copy()
+
+    async def fake_send_request(**kwargs):
+        calls.append(kwargs)
+        await plant._process_response(
+            tick_response(key, [100], [900_000], {"id": "discard-me"})
+        )
+        await plant._process_response(
+            MagicMock(
+                template_id=207,
+                rp_code=["8"],
+                rq_handler_rp_code=[],
+                user_msg=[key],
+            )
+        )
+
+    plant._send_request = AsyncMock(side_effect=fake_send_request)
+
+    with pytest.raises(RithmicErrorResponse):
+        await plant.get_historical_tick_data(
+            "MNQM6", "CME",
+            datetime.fromtimestamp(100, tz=timezone.utc),
+            datetime.fromtimestamp(200, tz=timezone.utc),
+        )
+
+    assert callback_ids == []
+    assert len(calls) == 1
+    assert key not in plant.historical_tick_requests
+
+
+async def test_tick_continuation_send_error_completes_and_cleans_up(
+    history_plant_mock, monkeypatch
+):
+    import importlib
+
+    history_module = importlib.import_module("async_rithmic.plants.history")
+    monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 2)
+    plant = history_plant_mock
+    key = "MNQM6_CME"
+    calls = []
+
+    async def fake_send_request(**kwargs):
+        calls.append(kwargs)
+        if len(calls) == 1:
+            await plant._process_response(
+                tick_response(key, [100], [900_000], {"id": "safe"})
+            )
+            await plant._process_response(
+                tick_response(key, [101], [0], {"id": "boundary"})
+            )
+            await plant._process_response(
+                tick_response(key, [], [], terminal=True)
+            )
+        else:
+            raise RuntimeError("continuation send failed")
+
+    plant._send_request = AsyncMock(side_effect=fake_send_request)
+
+    with pytest.raises(RuntimeError, match="continuation send failed"):
+        await plant.get_historical_tick_data(
+            "MNQM6", "CME",
+            datetime.fromtimestamp(100, tz=timezone.utc),
+            datetime.fromtimestamp(200, tz=timezone.utc),
+        )
+
+    assert len(calls) == 2
+    assert calls[1]["start_index"] == 101
+    assert key not in plant.historical_tick_requests
+
+
+async def test_subsecond_tick_bounds_are_floored(history_plant_mock):
+    plant = history_plant_mock
+    await plant.get_historical_tick_data(
+        "MNQM6", "CME",
+        datetime(2026, 4, 13, 0, 0, 0, 900_000, tzinfo=timezone.utc),
+        datetime(2026, 4, 13, 0, 1, 0, 100_000, tzinfo=timezone.utc),
+        wait=False,
+    )
+
+    request = plant._send_request.await_args.kwargs
+    assert request["start_index"] == int(datetime(
+        2026, 4, 13, 0, tzinfo=timezone.utc
+    ).timestamp())
+    assert request["finish_index"] == int(datetime(
+        2026, 4, 13, 0, 1, tzinfo=timezone.utc
+    ).timestamp())
+
+
+async def test_repeated_full_page_fails_instead_of_looping(
+    history_plant_mock, monkeypatch
+):
+    import importlib
+
+    history_module = importlib.import_module("async_rithmic.plants.history")
+    monkeypatch.setattr(history_module, "HISTORICAL_TICK_PAGE_SIZE", 4)
+    plant = history_plant_mock
+    callback_ids = []
+
+    async def on_tick(data):
+        callback_ids.append(data["id"])
+
+    plant.client.on_historical_tick += on_tick
+    page = [
+        ([100], [900_000], {"id": "safe"}),
+        ([101], [0], {"id": "boundary-zero"}),
+        ([101], [100_000], {"id": "boundary-a"}),
+        ([101], [200_000], {"id": "boundary-b"}),
+    ]
+    calls = configure_tick_responses(plant, [page, page])
+
+    with pytest.raises(HistoricalDataPaginationError):
+        await plant.get_historical_tick_data(
+            "MNQM6", "CME",
+            datetime.fromtimestamp(100, tz=timezone.utc),
+            datetime.fromtimestamp(200, tz=timezone.utc),
+        )
+
+    assert len(calls) == 2
+    assert callback_ids == ["safe"]
+    assert not plant.historical_tick_requests
 
 
 async def test_concurrent_different_symbols(history_plant_mock):

--- a/tests/test_request_manager.py
+++ b/tests/test_request_manager.py
@@ -3,7 +3,7 @@ import asyncio
 import uuid
 import random
 from collections import namedtuple
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from async_rithmic.helpers.request_manager import RequestManager
 
@@ -96,3 +96,47 @@ class TestRequestManager:
                 expected_response=dict(template_id=313, user_msg=[request_id]),
             )
 
+        assert not manager.requests
+        assert not manager.responses
+        assert not manager.expected_responses
+        assert not manager.done_events
+        assert not manager.start_times
+
+    async def test_send_failure_cleans_up_request(self, manager, plant):
+        request_id = str(uuid.uuid4())
+        send_error = RuntimeError("send failed")
+        plant._send_request = AsyncMock(side_effect=send_error)
+
+        with pytest.raises(RuntimeError, match="send failed"):
+            await manager.send_and_collect(
+                user_msg=request_id,
+                template_id=312,
+                expected_response=dict(template_id=313, user_msg=[request_id]),
+            )
+
+        assert not manager.requests
+        assert not manager.responses
+        assert not manager.expected_responses
+        assert not manager.done_events
+        assert not manager.start_times
+
+    async def test_cancelled_request_cleans_up_request(self, manager, plant):
+        request_id = str(uuid.uuid4())
+        plant._send_request = AsyncMock()
+
+        task = asyncio.create_task(manager.send_and_collect(
+            user_msg=request_id,
+            template_id=312,
+            expected_response=dict(template_id=313, user_msg=[request_id]),
+        ))
+        await asyncio.sleep(0)
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert not manager.requests
+        assert not manager.responses
+        assert not manager.expected_responses
+        assert not manager.done_events
+        assert not manager.start_times


### PR DESCRIPTION
  ## Summary

- Make historical tick pagination safe across same-second boundaries.
- Document coding style in AGENTS.md
- Added `progress_callback` when requesting historical data to notify consumers of progress
- Fail active historical requests promptly on disconnect.
- Disable automatic resend for in-flight historical tick requests.

  ## Compatibility note

  `get_historical_tick_data()` now defaults to `strict=True`; callers that intentionally accept bounded partial results should pass `strict=False`.
