### PR TITLE
Tolerate unknown template IDs instead of raising per frame

### DIFF
--- a/async_rithmic/helpers/background_task_mixin.py
+++ b/async_rithmic/helpers/background_task_mixin.py
@@ -149,6 +149,8 @@ class BackgroundTaskMixin:
             buffer = await self._inbound_queue.get()
             try:
                 response = self._convert_bytes_to_response(buffer)
+                if response is None:
+                    continue
                 self.logger.debug(f"Received message {MessageToDict(response)}")
 
                 await self._process_response(response)

--- a/async_rithmic/plants/base.py
+++ b/async_rithmic/plants/base.py
@@ -371,6 +371,8 @@ class BasePlant(BackgroundTaskMixin):
                 buffer = await self.ws.recv()
 
                 response = self._convert_bytes_to_response(buffer)
+                if response is None:
+                    continue
                 self.logger.debug(f"Received message {MessageToDict(response)}")
 
                 if response.template_id != kwargs["template_id"] + 1:
@@ -463,7 +465,12 @@ class BasePlant(BackgroundTaskMixin):
 
         template_id = base.template_id
         if template_id not in TEMPLATES_MAP:
-            raise Exception(f"Unknown template ID: {template_id}")
+            # Rithmic servers send templates newer than this map (e.g. 358 was
+            # observed on Rithmic 01 in production). An unknown frame is dropped
+            # with a warning instead of raising, so one unrecognized push cannot
+            # break response processing during a burst.
+            self.logger.warning(f"Skipping frame with unknown template ID: {template_id}")
+            return None
 
         # Parse as specific response class
         response_cls = TEMPLATES_MAP[template_id]


### PR DESCRIPTION
Rithmic production servers send template IDs newer than TEMPLATES_MAP. We observed template 358 on the Rithmic 01 system in August 2026, in bursts.

Today `_convert_bytes_to_response` raises on every unknown frame. In `_process_loop` that logs a full traceback per frame; in `_send_and_recv_immediate` (login path) the exception propagates and aborts the surrounding request.

This change drops an unknown frame with a warning instead: `_convert_bytes_to_response` returns `None` for an unknown template ID, and both call sites skip a `None` response. Known templates are unaffected.

Happy to adjust if you would rather add 358 to the map once its message type is confirmed; the 0.89 R|Protocol reference guide's template table ends at 357, so we could not name it with confidence.